### PR TITLE
Fixed bug with creating new brushes

### DIFF
--- a/Scripts/UI/Toolbar.cs
+++ b/Scripts/UI/Toolbar.cs
@@ -145,6 +145,8 @@ namespace Sabresaurus.SabreCSG
 					newPosition = hits[0].Point;
 					// Back a unit, since the brush is around 2 units in each dimensions
 					newPosition += hits[0].Normal;
+					newPosition -= csgModel.GetComponent<Transform>().position;
+
 					if(CurrentSettings.PositionSnappingEnabled)
 					{
 						float snapDistance = CurrentSettings.PositionSnapDistance;
@@ -161,6 +163,7 @@ namespace Sabresaurus.SabreCSG
                         newPosition = ray.GetPoint(hitDistance);
                         // Back a unit, since the brush is around 2 units in each dimensions
                         newPosition += activePlane.normal;
+						newPosition -= csgModel.GetComponent<Transform>().position;
 
                         if (CurrentSettings.PositionSnappingEnabled)
                         {


### PR DESCRIPTION
Bug: If the root CSGModel game object is moved from the origin then new brushes will not be created along the camera center. They will be offset from the expected position by the an amount equal to the position of the root CSGModel.

Fix: Subtract the world position of the root CSGModel game object from the newPosition vector that the brush will be created at.