### PR TITLE
New Feature: Quick Select

### DIFF
--- a/Scripts/Brushes/CompoundBrushes/Editor/StairBrushInspector.cs
+++ b/Scripts/Brushes/CompoundBrushes/Editor/StairBrushInspector.cs
@@ -24,7 +24,10 @@ namespace Sabresaurus.SabreCSG
 		// Whether the stairs align to the bottom edge or the top edge
 		SerializedProperty leadFromTopProp;
 
-		protected override void OnEnable ()
+        // Whether the height of each step is stretched to the floor to fill it
+		SerializedProperty fillToBottom;
+
+        protected override void OnEnable ()
 		{
 			base.OnEnable ();
 			// Setup the SerializedProperties.
@@ -38,7 +41,8 @@ namespace Sabresaurus.SabreCSG
             autoHeightProp = serializedObject.FindProperty ("autoHeight");
 
 			leadFromTopProp = serializedObject.FindProperty ("leadFromTop");
-		}
+            fillToBottom = serializedObject.FindProperty ("fillToBottom");
+        }
 
 		public override void OnInspectorGUI()
 		{
@@ -76,6 +80,8 @@ namespace Sabresaurus.SabreCSG
 	                ApplyAndInvalidate();
 	            }
 
+                EditorGUILayout.BeginHorizontal();
+
 	            bool oldValue = leadFromTopProp.boolValue;
 				bool newValue = GUILayout.Toggle(oldValue, "Lead From Top", EditorStyles.toolbarButton);
 				if(newValue != oldValue)
@@ -84,7 +90,19 @@ namespace Sabresaurus.SabreCSG
 					serializedObject.ApplyModifiedProperties();
 					System.Array.ForEach(BrushTargets, item => item.Invalidate(true));
 				}
-				EditorGUILayout.Space();
+
+                oldValue = fillToBottom.boolValue;
+                newValue = GUILayout.Toggle(oldValue, "Fill To Bottom", EditorStyles.toolbarButton);
+                if (newValue != oldValue)
+                {
+                    fillToBottom.boolValue = newValue;
+                    serializedObject.ApplyModifiedProperties();
+                    System.Array.ForEach(BrushTargets, item => item.Invalidate(true));
+                }
+
+                EditorGUILayout.EndHorizontal();
+
+                EditorGUILayout.Space();
 			}
 
 			base.OnInspectorGUI();
@@ -115,10 +133,21 @@ namespace Sabresaurus.SabreCSG
             stepRect1.center += new Vector2(-stepUISize.x - stepUISpacing.x/2f, stepUISpacing.y / 2f);
             GUI.Box(stepRect1, new GUIContent());
 
+            // Calculate top right step size
+            float stepHeight2 = stepUISize.y;
+
+            // Apply the fill to bottom height for drawing
+            if (fillToBottom.boolValue)
+                stepHeight2 = stepUISize.y * 2 + stepUISpacing.y;
+
             // Draw top right step
-            Rect stepRect2 = new Rect(centerOffset.x, centerOffset.y, stepUISize.x, stepUISize.y);
+            Rect stepRect2 = new Rect(centerOffset.x, centerOffset.y, stepUISize.x, stepHeight2);
             stepRect2.center += new Vector2(stepUISpacing.x / 2f, -stepUISize.y - stepUISpacing.y/2f);
             GUI.Box(stepRect2, new GUIContent());
+
+            // Undo the fill to bottom height
+            if (fillToBottom.boolValue)
+                stepRect2.height -= stepUISize.y + stepUISpacing.y;
 
             // Draw depth spacing lines          
             GUI.color = Color.grey;

--- a/Scripts/Brushes/CompoundBrushes/StairBrush.cs
+++ b/Scripts/Brushes/CompoundBrushes/StairBrush.cs
@@ -30,7 +30,10 @@ namespace Sabresaurus.SabreCSG
 		[SerializeField]
 		bool leadFromTop = false;
 
-		public override int BrushCount 
+        [SerializeField]
+        bool fillToBottom = false;
+
+        public override int BrushCount 
 		{
 			get 
 			{
@@ -81,14 +84,17 @@ namespace Sabresaurus.SabreCSG
 				
 			for (int i = 0; i < brushCount; i++) 
 			{
-				Vector3 localPosition = startPosition + Vector3.forward * i * (activeDepth + stepDepthSpacing) + Vector3.up * i * (activeHeight + stepHeightSpacing);
-				generatedBrushes[i].transform.localPosition = localPosition;
+                Vector3 localPosition = startPosition + Vector3.forward * i * (activeDepth + stepDepthSpacing) + Vector3.up * i * (activeHeight + stepHeightSpacing) * (fillToBottom ? 0.5f : 1f);
+                generatedBrushes[i].transform.localPosition = localPosition;
 
 				generatedBrushes[i].Mode = this.Mode;
 				generatedBrushes[i].IsNoCSG = this.IsNoCSG;
 				generatedBrushes[i].IsVisible = this.IsVisible;
 				generatedBrushes[i].HasCollision = this.HasCollision;
 				BrushUtility.Resize(generatedBrushes[i], stepSize);
+
+                if (fillToBottom)
+                    stepSize.y += (activeHeight) + stepHeightSpacing;
 			}
 		}
 	}

--- a/Scripts/Tools/SurfaceEditor.cs
+++ b/Scripts/Tools/SurfaceEditor.cs
@@ -1025,7 +1025,6 @@ namespace Sabresaurus.SabreCSG
                     Polygon polygon = selectedSourcePolygons[polygonIndex];
                     Brush brush = csgModel.FindBrushFromPolygon(polygon);
 
-                    // todo: I don't understand... are the normals simply inverted due to some math bug elsewhere? Inverting my logic depending on the CSG Mode fixes it...
                     if (brush.Mode == CSGMode.Add)
                     {
                         // is the camera on the positive side of the plane?


### PR DESCRIPTION
Previously you had to select each face you wanted to use individually until your finger cramped:
![previously](https://user-images.githubusercontent.com/7905726/30776733-ef7aefd4-a0ab-11e7-8992-6c4bd742ad79.gif)

Now you just hold shift, press the left mouse button and move over the faces you want to select:
![quickselect](https://user-images.githubusercontent.com/7905726/30776740-082f430e-a0ac-11e7-8883-58c16a0ab2c4.gif)
