### PR TITLE
Fixed the deselecting of faces that are behind the face you clicked on

### DIFF
--- a/Scripts/Tools/SurfaceEditor.cs
+++ b/Scripts/Tools/SurfaceEditor.cs
@@ -180,10 +180,32 @@ namespace Sabresaurus.SabreCSG
                 List<Polygon> raycastHits = csgModel.RaycastBuiltPolygonsAll(ray).Select(hit => csgModel.GetSourcePolygon(hit.Polygon.UniqueIndex)).Where(item => item != null).ToList();
                 Polygon sourcePolygon = null;
 
-                // Use the first polygon that was hit so we don't accidentally select/deselect polygons behind the one we see.
-                if (raycastHits.Count > 0)
+                // User is trying to multiselect, let's not make life difficult for them by only accepting the nearest polygon
+                if (SabreInput.IsModifier(e, EventModifiers.Shift))
                 {
-                    sourcePolygon = raycastHits[0];
+                    // Use the first polygon that was hit
+                    if (raycastHits.Count > 0)
+                    {
+                        sourcePolygon = raycastHits[0];
+                    }
+                }
+                else
+                {
+                    // Walk through the hits from front to back and find if any of them are in the selection set
+                    for (int i = 0; i < raycastHits.Count; i++)
+                    {
+                        if (selectedSourcePolygons.Contains(raycastHits[i]))
+                        {
+                            sourcePolygon = raycastHits[i];
+                            break;
+                        }
+                    }
+
+                    // None of the hit polygons are in the selection set, so just use the first hit polygon if it's available
+                    if (sourcePolygon == null && raycastHits.Count >= 1)
+                    {
+                        sourcePolygon = raycastHits[0];
+                    }
                 }
 
                 // If a polygon has been hit

--- a/Scripts/Tools/SurfaceEditor.cs
+++ b/Scripts/Tools/SurfaceEditor.cs
@@ -178,9 +178,13 @@ namespace Sabresaurus.SabreCSG
 
                 // Get all the polygons the ray hits
                 List<Polygon> raycastHits = csgModel.RaycastBuiltPolygonsAll(ray).Select(hit => csgModel.GetSourcePolygon(hit.Polygon.UniqueIndex)).Where(item => item != null).ToList();
+                Polygon sourcePolygon = null;
 
                 // Use the first polygon that was hit so we don't accidentally select/deselect polygons behind the one we see.
-                Polygon sourcePolygon = raycastHits[0];
+                if (raycastHits.Count > 0)
+                {
+                    sourcePolygon = raycastHits[0];
+                }
 
                 // If a polygon has been hit
                 if (sourcePolygon != null)

--- a/Scripts/Tools/SurfaceEditor.cs
+++ b/Scripts/Tools/SurfaceEditor.cs
@@ -178,26 +178,12 @@ namespace Sabresaurus.SabreCSG
 
                 // Get all the polygons the ray hits
                 List<Polygon> raycastHits = csgModel.RaycastBuiltPolygonsAll(ray).Select(hit => csgModel.GetSourcePolygon(hit.Polygon.UniqueIndex)).Where(item => item != null).ToList();
-                Polygon sourcePolygon = null;
 
-                // Walk through the hits from front to back and find if any of them are in the selection set
-                for (int i = 0; i < raycastHits.Count; i++)
-                {
-                    if(selectedSourcePolygons.Contains(raycastHits[i]))
-                    {
-                        sourcePolygon = raycastHits[i];
-                        break;
-                    }
-                }
-
-                // None of the hit polygons are in the selection set, so just use the first hit polygon if it's available
-                if(sourcePolygon == null && raycastHits.Count >= 1)
-                {
-                    sourcePolygon = raycastHits[0];
-                }
+                // Use the first polygon that was hit so we don't accidentally select/deselect polygons behind the one we see.
+                Polygon sourcePolygon = raycastHits[0];
 
                 // If a polygon has been hit
-				if(sourcePolygon != null)
+                if (sourcePolygon != null)
                 {
                     // Reset drag values
                     totalDelta = Vector2.zero;


### PR DESCRIPTION
SurfaceEditor: We now use the first polygon that was hit so we don't accidentally select/deselect polygons behind the one we see. A very annoying bug that was fixed by removing a lot of code that apparently doesn't do anything useful.

Correct me if I am wrong, but I tried everything I could think of and it works perfectly, I have no idea what all that code was doing.

Also to replicate the bug I am talking about, select a face, move your camera so it's covered by another face, try selecting that one, the face behind it will be deselected and the face you clicked stays deselected. An annoying bug because the wrong raycast hits were used instead of the first. I found the solution by looking at how CTRL-click does it on mouse-up where you already fixed this problem the same way. "// User is trying to multiselect, let's not make life difficult for them, by only accepting the nearest polygon".