### PR TITLE
Fixes #26 Brush moves erroneously when set to non-one scale.

### DIFF
--- a/Scripts/Brushes/PrimitiveBrush.cs
+++ b/Scripts/Brushes/PrimitiveBrush.cs
@@ -817,7 +817,7 @@ namespace Sabresaurus.SabreCSG
 			}
 
 			// Bounds is aligned with the object
-			transform.Translate(delta);
+			transform.Translate(delta.Multiply(transform.localScale));
 
 			// Counter the delta offset
 			Transform[] childTransforms = transform.GetComponentsInChildren<Transform>(true);


### PR DESCRIPTION
I can't recommend scaling brushes like this but at least this stops random re-positioning for any users that do so regardless.

The transformation controls (and visual bounds) are scaling properly, be it the root "CSGModel" or compound brushes. However, their child brushes' built geometry does not scale relative to the parent. If we can add support for that we'd probably support scaling completely and can thus also fix issue #23.