### PR TITLE
Changed the default shadow casting mode from On to TwoSided

### DIFF
--- a/Scripts/Core/CSGBuildSettings.cs
+++ b/Scripts/Core/CSGBuildSettings.cs
@@ -31,7 +31,50 @@ namespace Sabresaurus.SabreCSG
 		public float UnwrapHardAngle = 88f; // degrees, 0 to 180
 		public float UnwrapPackMargin = 0.00390625f; // Assumes a 1024 texture, pack margin = PadPixels / 1024
 
-        public ShadowCastingMode ShadowCastingMode = ShadowCastingMode.On;
+        /*
+            Fix most of the light leaking that occurs after CSG operations.
+            See https://github.com/sabresaurus/SabreCSG/issues/19#issuecomment-358567922
+
+            In Unity even a simple box placement like below will cause dynamic light to leak through
+            what may appear to be a closed corner to the player:
+
+              Dynamic
+            Light Source
+                X    +------+
+                 X   |      |
+                  X  |      |
+                   X |      |
+                    X+------+
+             +------+X
+             |      | X
+             |      |  X
+             |      |   X
+             +------+    X
+                     Light Leaks Through
+                        Causes Seam
+
+            When CSG operations hollow out brushes you may get a shape like this with the same problem:
+
+              Dynamic
+            Light Source
+                X
+                 X   +------+
+                  X  |      |
+                   X |      |
+                    X|      |
+                 +---+  +---+   <---+ NoCSG would not have caused a hole here.
+                 |    X |
+                 |     X|   <---+ This wall's normal is facing the wrong way
+                 |      |         and will not block the incoming light.
+                 +------+X
+                     Light Leaks Through
+                        Causes Seam
+
+            By setting the shadow casting mode of the mesh to be "Two Sided" the backfacing wall will
+            block the incoming light and prevent the light leak artifact from appearing.
+       */
+
+        public ShadowCastingMode ShadowCastingMode = ShadowCastingMode.TwoSided;
 
 		// What default physics material to use on collision meshes
 		public PhysicMaterial DefaultPhysicsMaterial = null;

--- a/Scripts/Core/CSGBuildSettings.cs
+++ b/Scripts/Core/CSGBuildSettings.cs
@@ -40,16 +40,16 @@ namespace Sabresaurus.SabreCSG
 
               Dynamic
             Light Source
-                X    +------+
-                 X   |      |
-                  X  |      |
-                   X |      |
-                    X+------+
-             +------+X
+               X    
+                X   +------+
+                 X  |      |
+                  X |      |
+                   X|      |
+             +------+------+
+             |      |X
              |      | X
              |      |  X
-             |      |   X
-             +------+    X
+             +------+   X
                      Light Leaks Through
                         Causes Seam
 


### PR DESCRIPTION
This helps prevent light leaks from occurring. It is one of the recommended ways to fix this. See the code for more details on why CSG operations will cause them in the first place. This also helps with stair cases reducing the leaks. #19 

![lightleaks](https://user-images.githubusercontent.com/7905726/36254856-f04b11b0-124c-11e8-867c-184e84ae0da2.gif)

![lightleaksstairs](https://user-images.githubusercontent.com/7905726/36254998-7e81b13c-124d-11e8-9d74-535e1c8afae2.gif)

The last step we cannot influence is the "Normal Bias" of the dynamic light source. If you reduce it to zero you will now have fixed all of the artifacts.

![lightnormalbias](https://user-images.githubusercontent.com/7905726/36255112-f7d9bf8e-124d-11e8-8fa5-22ae7e1a3784.png)

![image](https://user-images.githubusercontent.com/7905726/36255123-00d1e4cc-124e-11e8-9a95-56199b32b471.png)

But by using this as the new default shadow casting mode we can at least help those users that are not aware of the normal bias and improve their user experience.

Any user that bakes static lightmaps will not experience any leaks regardless of their light settings now.