### PR TITLE
[Suggestion] Hiding brushes when the camera gets close to them?

### DIFF
--- a/Internal/Shaders/BrushPreview.shader
+++ b/Internal/Shaders/BrushPreview.shader
@@ -1,32 +1,36 @@
 ﻿// Based on "Legacy Shaders/Transparent/Diffuse"
 Shader "SabreCSG/BrushPreview"
 {
-Properties {
-	_Color ("Main Color", Color) = (1,1,1,1)
-}
+	Properties
+	{
+		_Color ("Main Color", Color) = (1,1,1,1)
+	}
 
-SubShader {
-	Fog { Mode Off }
-	Tags {"Queue"="Transparent" "IgnoreProjector"="True" "RenderType"="Transparent"}
-	LOD 200
+	SubShader
+	{
+		Fog { Mode Off }
+		Tags {"Queue"="Transparent" "IgnoreProjector"="True" "RenderType"="Transparent"}
+		LOD 200
 
-CGPROGRAM
-#pragma surface surf Lambert alpha:blend nofog
+		CGPROGRAM
+		#pragma surface surf Lambert alpha:blend nofog
 
-fixed4 _Color;
+		fixed4 _Color;
 
-struct Input {
-	fixed4 color; // Can't declare empty structs in CG, so just put a filler variable to get it compiling
-};
+		struct Input
+		{
+			float3 worldPos;
+		};
 
-void surf (Input IN, inout SurfaceOutput o) {
-	fixed4 c = _Color;
+		void surf (Input IN, inout SurfaceOutput o)
+		{
+			fixed4 c = _Color;
 	
-	o.Albedo = c.rgb;
-	o.Alpha = c.a;
-}
-ENDCG
-}
+			o.Albedo = c.rgb;
+			o.Alpha = clamp((distance(IN.worldPos, _WorldSpaceCameraPos) * 0.2f) - 1.0f, 0.0f, c.a);
+		}
+		ENDCG
+	}
 
-Fallback "Legacy Shaders/Transparent/VertexLit"
+	Fallback "Legacy Shaders/Transparent/VertexLit"
 }


### PR DESCRIPTION
Brushes, especially several subtractive ones obfuscate the view into bright yellow and it's no longer see-through. I made it so that the brushes disappear when the camera gets close to them so you can have the best of both worlds and also see your texturing work up close.

![nightmare](https://user-images.githubusercontent.com/7905726/36398126-dfc1ecd4-15c5-11e8-90c1-70be7ae5ff8b.png)

I think this will especially benefit the Auto Rebuild users as bright yellow things won't allow you to see what you are doing, so you turn brushes off, but now you have a bounding box with something invisible, it's a pain. Especially interiors are difficult to make but this helps.

![antibrush](https://user-images.githubusercontent.com/7905726/36397342-b400c28a-15c2-11e8-835c-b5cafc8aa9c3.gif)

![antibrush2](https://user-images.githubusercontent.com/7905726/36397348-b8d15cc0-15c2-11e8-9b34-a639a6475974.gif)

If you think this should only be done on subtractive brushes or it should be a special "Brushes Hidden, Brushes Fading, Brushes Visible" toggle or possibly only have this happen when auto rebuild is used and we disable additive brushes but use this for visibility on subtractive brushes or this was a terrible idea or we should invert the logic so only things you work on show up as brushes or have other suggestions, please do share your thoughts. :)

Edit: Right now this may be annoying for people that never ever rebuild for some reason.