### PR TITLE
Added a configuration option to display brushes as wireframes.

### DIFF
--- a/Scripts/Brushes/PrimitiveBrush.cs
+++ b/Scripts/Brushes/PrimitiveBrush.cs
@@ -567,81 +567,77 @@ namespace Sabresaurus.SabreCSG
 				return;
 			}
 
-			// Make sure there is a mesh filter on this object
-			MeshFilter meshFilter = gameObject.AddOrGetComponent<MeshFilter>();
-			MeshRenderer meshRenderer = gameObject.AddOrGetComponent<MeshRenderer>();
+            // previous versions of sabrecsg used to use mesh colliders for ray collision, but that's no longer the case so we clean them up.
+            MeshCollider[] meshColliders = GetComponents<MeshCollider>();
+            if (meshColliders.Length > 0)
+                for (int i = 0; i < meshColliders.Length; i++)
+                    DestroyImmediate(meshColliders[i]);
 
-			// Used to use mesh colliders for ray collision, but not any more so clean them up
-			MeshCollider[] meshColliders = GetComponents<MeshCollider>();
 
-			if(meshColliders.Length > 0)
-			{
-				for (int i = 0; i < meshColliders.Length; i++) 
-				{
-					DestroyImmediate(meshColliders[i]);
-				}
-			} 
+            // Make sure there is a mesh filter on this object
+            MeshFilter meshFilter = gameObject.AddOrGetComponent<MeshFilter>();
+            MeshRenderer meshRenderer = gameObject.AddOrGetComponent<MeshRenderer>();
 
-			bool requireRegen = false;
+            bool requireRegen = false;
 
-			// If the cached ID hasn't been set or we mismatch
-			if(cachedInstanceID == 0
-				|| gameObject.GetInstanceID() != cachedInstanceID)
-			{
-				requireRegen = true;
-				cachedInstanceID = gameObject.GetInstanceID();
-			}
+            // If the cached ID hasn't been set or we mismatch
+            if (cachedInstanceID == 0
+                || gameObject.GetInstanceID() != cachedInstanceID)
+            {
+                requireRegen = true;
+                cachedInstanceID = gameObject.GetInstanceID();
+            }
 
-			Mesh renderMesh = meshFilter.sharedMesh;
+            Mesh renderMesh = meshFilter.sharedMesh;
 
-			if(requireRegen)
-			{
-				renderMesh = new Mesh();
-			}
+            if (requireRegen)
+            {
+                renderMesh = new Mesh();
+            }
 
-			if(polygons != null)
-			{
-				List<int> polygonIndices;
-				BrushFactory.GenerateMeshFromPolygons(polygons, ref renderMesh, out polygonIndices);
-			}
+            if (polygons != null)
+            {
+                List<int> polygonIndices;
+                BrushFactory.GenerateMeshFromPolygons(polygons, ref renderMesh, out polygonIndices);
+            }
 
-			if(mode == CSGMode.Subtract)
-			{
-				MeshHelper.Invert(ref renderMesh);
-			}
-			// Displace the triangles for display along the normals very slightly (this is so we can overlay built
-			// geometry with semi-transparent geometry and avoid depth fighting)
-			MeshHelper.Displace(ref renderMesh, 0.001f);
+            if (mode == CSGMode.Subtract)
+            {
+                MeshHelper.Invert(ref renderMesh);
+            }
+            // Displace the triangles for display along the normals very slightly (this is so we can overlay built
+            // geometry with semi-transparent geometry and avoid depth fighting)
+            MeshHelper.Displace(ref renderMesh, 0.001f);
 
-			meshFilter.sharedMesh = renderMesh;
-				
-			meshRenderer.receiveShadows = false;
-			meshRenderer.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
+            meshFilter.sharedMesh = renderMesh;
 
-			meshFilter.hideFlags = HideFlags.NotEditable;// | HideFlags.HideInInspector;
-			meshRenderer.hideFlags = HideFlags.NotEditable;// | HideFlags.HideInInspector;
+            meshRenderer.receiveShadows = false;
+            meshRenderer.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
+
+            meshFilter.hideFlags = HideFlags.NotEditable;// | HideFlags.HideInInspector;
+            meshRenderer.hideFlags = HideFlags.NotEditable;// | HideFlags.HideInInspector;
 
 #if UNITY_EDITOR
-			Material material;
-			if(IsNoCSG)
-			{
-				material = SabreCSGResources.GetNoCSGMaterial();
-			}
-			else
-			{
-				if(this.mode == CSGMode.Add)
-				{
-					material = SabreCSGResources.GetAddMaterial();
-				}
-				else
-				{
-					material = SabreCSGResources.GetSubtractMaterial();
-				}
-			}
-			if(meshRenderer.sharedMaterial != material)
-			{
-				meshRenderer.sharedMaterial = material;
-			}
+            Material material;
+            if (IsNoCSG)
+            {
+                material = SabreCSGResources.GetNoCSGMaterial();
+            }
+            else
+            {
+                if (this.mode == CSGMode.Add)
+                {
+                    material = SabreCSGResources.GetAddMaterial();
+                }
+                else
+                {
+                    material = SabreCSGResources.GetSubtractMaterial();
+                }
+            }
+            if (meshRenderer.sharedMaterial != material)
+            {
+                meshRenderer.sharedMaterial = material;
+            }
 #endif
 //			isBrushConvex = GeometryHelper.IsBrushConvex(polygons);
 
@@ -674,7 +670,7 @@ namespace Sabresaurus.SabreCSG
             MeshRenderer meshRenderer = GetComponent<MeshRenderer>();
             if (meshRenderer != null)
             {
-                meshRenderer.enabled = isVisible;
+                meshRenderer.enabled = isVisible && !CurrentSettings.ShowBrushesAsWireframes;
             }
         }
 

--- a/Scripts/CurrentSettings.cs
+++ b/Scripts/CurrentSettings.cs
@@ -137,7 +137,19 @@ namespace Sabresaurus.SabreCSG
 			}
 		}
 
-		public static bool ReducedHandleThreshold
+        public static bool ShowBrushesAsWireframes
+        {
+            get
+            {
+                return PlayerPrefs.GetInt(KEY_PREFIX + "ShowBrushesAsWireframes", 0) != 0;
+            }
+            set
+            {
+                PlayerPrefs.SetInt(KEY_PREFIX + "ShowBrushesAsWireframes", value ? 1 : 0);
+            }
+        }
+
+        public static bool ReducedHandleThreshold
 		{
 			get
 			{

--- a/Scripts/UI/SabreCSGPreferences.cs
+++ b/Scripts/UI/SabreCSGPreferences.cs
@@ -81,7 +81,16 @@ namespace Sabresaurus.SabreCSG
 				SceneView.RepaintAll();
 			}
 
-			GUILayout.Space(10);
+            EditorGUI.BeginChangeCheck();
+            CurrentSettings.ShowBrushesAsWireframes = GUILayout.Toggle(CurrentSettings.ShowBrushesAsWireframes, "Show brushes as wireframes");
+            if (EditorGUI.EndChangeCheck())
+            {
+                // What's shown in the SceneView has potentially changed, so force it to repaint
+                CSGModel.UpdateAllBrushesVisibility();
+                SceneView.RepaintAll();
+            }
+
+            GUILayout.Space(10);
 
 			if(GUILayout.Button("Change key mappings"))
 			{


### PR DESCRIPTION
This is a feature I really wanted, it helps with visibility. Resolves #45.

![brushesaswireframes](https://user-images.githubusercontent.com/7905726/36998543-8d1f2f16-20bd-11e8-842b-9865d9038b10.gif)

The commit looks worse than it is, in the end all I did was remove some unrelated curly braces and clean a comment. This is the only code that got changed in PrimitiveBrush.cs:

![image](https://user-images.githubusercontent.com/7905726/36998612-c79ac48e-20bd-11e8-96ae-cd2a7faa4800.png)