### PR TITLE
Cleaned up the shaders. Backwards compatibility with Unity 5.3.0f4.

### DIFF
--- a/Gizmos/ButtonCone.png.meta
+++ b/Gizmos/ButtonCone.png.meta
@@ -4,17 +4,14 @@ timeCreated: 1516191689
 licenseType: Free
 TextureImporter:
   fileIDToRecycleName: {}
-  externalObjects: {}
-  serializedVersion: 4
+  serializedVersion: 2
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
-    sRGBTexture: 0
-    linearTexture: 0
+    linearTexture: 1
+    correctGamma: 0
     fadeOut: 0
     borderMipMap: 0
-    mipMapsPreserveCoverage: 0
-    alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
     mipMapFadeDistanceEnd: 3
   bumpmap:
@@ -24,22 +21,23 @@ TextureImporter:
     normalMapFilter: 0
   isReadable: 0
   grayScaleToAlpha: 0
-  generateCubemap: 6
+  generateCubemap: 0
   cubemapConvolution: 0
+  cubemapConvolutionSteps: 7
+  cubemapConvolutionExponent: 1.5
   seamlessCubemap: 0
-  textureFormat: 1
+  textureFormat: -3
   maxTextureSize: 2048
   textureSettings:
-    serializedVersion: 2
-    filterMode: -1
+    filterMode: 1
     aniso: 1
     mipBias: -1
-    wrapU: 1
-    wrapV: 1
-    wrapW: -1
+    wrapMode: 1
   nPOTScale: 0
   lightmap: 0
+  rGBM: 0
   compressionQuality: 50
+  allowsAlphaSplitting: 0
   spriteMode: 0
   spriteExtrude: 1
   spriteMeshType: 1
@@ -47,40 +45,12 @@ TextureImporter:
   spritePivot: {x: 0.5, y: 0.5}
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spritePixelsToUnits: 100
-  alphaUsage: 1
   alphaIsTransparency: 1
-  spriteTessellationDetail: -1
   textureType: 2
-  textureShape: 1
-  maxTextureSizeSet: 0
-  compressionQualitySet: 0
-  textureFormatSet: 0
-  platformSettings:
-  - buildTarget: DefaultTexturePlatform
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 0
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
-  - buildTarget: Standalone
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 0
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
+  buildTargetSettings: []
   spriteSheet:
-    serializedVersion: 2
     sprites: []
     outline: []
-    physicsShape: []
   spritePackingTag: 
   userData: 
   assetBundleName: 

--- a/Gizmos/ButtonCube.png.meta
+++ b/Gizmos/ButtonCube.png.meta
@@ -46,7 +46,6 @@ TextureImporter:
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spritePixelsToUnits: 100
   alphaIsTransparency: 1
-  spriteTessellationDetail: -1
   textureType: 2
   buildTargetSettings: []
   spriteSheet:

--- a/Gizmos/ButtonCurvedStairs.png.meta
+++ b/Gizmos/ButtonCurvedStairs.png.meta
@@ -4,17 +4,14 @@ timeCreated: 1516366704
 licenseType: Free
 TextureImporter:
   fileIDToRecycleName: {}
-  externalObjects: {}
-  serializedVersion: 4
+  serializedVersion: 2
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
-    sRGBTexture: 0
-    linearTexture: 0
+    linearTexture: 1
+    correctGamma: 0
     fadeOut: 0
     borderMipMap: 0
-    mipMapsPreserveCoverage: 0
-    alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
     mipMapFadeDistanceEnd: 3
   bumpmap:
@@ -24,22 +21,23 @@ TextureImporter:
     normalMapFilter: 0
   isReadable: 0
   grayScaleToAlpha: 0
-  generateCubemap: 6
+  generateCubemap: 0
   cubemapConvolution: 0
+  cubemapConvolutionSteps: 7
+  cubemapConvolutionExponent: 1.5
   seamlessCubemap: 0
-  textureFormat: 1
+  textureFormat: -3
   maxTextureSize: 2048
   textureSettings:
-    serializedVersion: 2
-    filterMode: -1
+    filterMode: 1
     aniso: 1
     mipBias: -1
-    wrapU: 1
-    wrapV: 1
-    wrapW: -1
+    wrapMode: 1
   nPOTScale: 0
   lightmap: 0
+  rGBM: 0
   compressionQuality: 50
+  allowsAlphaSplitting: 0
   spriteMode: 0
   spriteExtrude: 1
   spriteMeshType: 1
@@ -47,40 +45,12 @@ TextureImporter:
   spritePivot: {x: 0.5, y: 0.5}
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spritePixelsToUnits: 100
-  alphaUsage: 1
   alphaIsTransparency: 1
-  spriteTessellationDetail: -1
   textureType: 2
-  textureShape: 1
-  maxTextureSizeSet: 0
-  compressionQualitySet: 0
-  textureFormatSet: 0
-  platformSettings:
-  - buildTarget: DefaultTexturePlatform
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 0
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
-  - buildTarget: Standalone
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 0
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
+  buildTargetSettings: []
   spriteSheet:
-    serializedVersion: 2
     sprites: []
     outline: []
-    physicsShape: []
   spritePackingTag: 
   userData: 
   assetBundleName: 

--- a/Gizmos/ButtonCylinder.png.meta
+++ b/Gizmos/ButtonCylinder.png.meta
@@ -29,7 +29,7 @@ TextureImporter:
   textureFormat: -3
   maxTextureSize: 2048
   textureSettings:
-    filterMode: -1
+    filterMode: 1
     aniso: 1
     mipBias: -1
     wrapMode: 1
@@ -46,7 +46,6 @@ TextureImporter:
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spritePixelsToUnits: 100
   alphaIsTransparency: 1
-  spriteTessellationDetail: -1
   textureType: 2
   buildTargetSettings: []
   spriteSheet:

--- a/Gizmos/ButtonIcoSphere.png.meta
+++ b/Gizmos/ButtonIcoSphere.png.meta
@@ -4,17 +4,14 @@ timeCreated: 1518470967
 licenseType: Free
 TextureImporter:
   fileIDToRecycleName: {}
-  externalObjects: {}
-  serializedVersion: 4
+  serializedVersion: 2
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
-    sRGBTexture: 0
-    linearTexture: 0
+    linearTexture: 1
+    correctGamma: 0
     fadeOut: 0
     borderMipMap: 0
-    mipMapsPreserveCoverage: 0
-    alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
     mipMapFadeDistanceEnd: 3
   bumpmap:
@@ -24,22 +21,23 @@ TextureImporter:
     normalMapFilter: 0
   isReadable: 0
   grayScaleToAlpha: 0
-  generateCubemap: 6
+  generateCubemap: 0
   cubemapConvolution: 0
+  cubemapConvolutionSteps: 7
+  cubemapConvolutionExponent: 1.5
   seamlessCubemap: 0
-  textureFormat: 1
+  textureFormat: -3
   maxTextureSize: 2048
   textureSettings:
-    serializedVersion: 2
-    filterMode: -1
+    filterMode: 1
     aniso: 1
     mipBias: -1
-    wrapU: 1
-    wrapV: 1
-    wrapW: -1
+    wrapMode: 1
   nPOTScale: 0
   lightmap: 0
+  rGBM: 0
   compressionQuality: 50
+  allowsAlphaSplitting: 0
   spriteMode: 0
   spriteExtrude: 1
   spriteMeshType: 1
@@ -47,40 +45,12 @@ TextureImporter:
   spritePivot: {x: 0.5, y: 0.5}
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spritePixelsToUnits: 100
-  alphaUsage: 1
   alphaIsTransparency: 1
-  spriteTessellationDetail: -1
   textureType: 2
-  textureShape: 1
-  maxTextureSizeSet: 0
-  compressionQualitySet: 0
-  textureFormatSet: 0
-  platformSettings:
-  - buildTarget: DefaultTexturePlatform
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 0
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
-  - buildTarget: Standalone
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 0
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
+  buildTargetSettings: []
   spriteSheet:
-    serializedVersion: 2
     sprites: []
     outline: []
-    physicsShape: []
   spritePackingTag: 
   userData: 
   assetBundleName: 

--- a/Gizmos/ButtonPrism.png.meta
+++ b/Gizmos/ButtonPrism.png.meta
@@ -29,7 +29,7 @@ TextureImporter:
   textureFormat: -3
   maxTextureSize: 2048
   textureSettings:
-    filterMode: -1
+    filterMode: 1
     aniso: 1
     mipBias: -1
     wrapMode: 1
@@ -46,7 +46,6 @@ TextureImporter:
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spritePixelsToUnits: 100
   alphaIsTransparency: 1
-  spriteTessellationDetail: -1
   textureType: 2
   buildTargetSettings: []
   spriteSheet:

--- a/Gizmos/ButtonShapeEditor.png.meta
+++ b/Gizmos/ButtonShapeEditor.png.meta
@@ -4,17 +4,14 @@ timeCreated: 1518471344
 licenseType: Free
 TextureImporter:
   fileIDToRecycleName: {}
-  externalObjects: {}
-  serializedVersion: 4
+  serializedVersion: 2
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
-    sRGBTexture: 0
-    linearTexture: 0
+    linearTexture: 1
+    correctGamma: 0
     fadeOut: 0
     borderMipMap: 0
-    mipMapsPreserveCoverage: 0
-    alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
     mipMapFadeDistanceEnd: 3
   bumpmap:
@@ -24,22 +21,23 @@ TextureImporter:
     normalMapFilter: 0
   isReadable: 0
   grayScaleToAlpha: 0
-  generateCubemap: 6
+  generateCubemap: 0
   cubemapConvolution: 0
+  cubemapConvolutionSteps: 7
+  cubemapConvolutionExponent: 1.5
   seamlessCubemap: 0
-  textureFormat: 1
+  textureFormat: -3
   maxTextureSize: 2048
   textureSettings:
-    serializedVersion: 2
-    filterMode: -1
+    filterMode: 1
     aniso: 1
     mipBias: -1
-    wrapU: 1
-    wrapV: 1
-    wrapW: -1
+    wrapMode: 1
   nPOTScale: 0
   lightmap: 0
+  rGBM: 0
   compressionQuality: 50
+  allowsAlphaSplitting: 0
   spriteMode: 0
   spriteExtrude: 1
   spriteMeshType: 1
@@ -47,40 +45,12 @@ TextureImporter:
   spritePivot: {x: 0.5, y: 0.5}
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spritePixelsToUnits: 100
-  alphaUsage: 1
   alphaIsTransparency: 1
-  spriteTessellationDetail: -1
   textureType: 2
-  textureShape: 1
-  maxTextureSizeSet: 0
-  compressionQualitySet: 0
-  textureFormatSet: 0
-  platformSettings:
-  - buildTarget: DefaultTexturePlatform
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 0
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
-  - buildTarget: Standalone
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 0
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
+  buildTargetSettings: []
   spriteSheet:
-    serializedVersion: 2
     sprites: []
     outline: []
-    physicsShape: []
   spritePackingTag: 
   userData: 
   assetBundleName: 

--- a/Gizmos/ButtonSphere.png.meta
+++ b/Gizmos/ButtonSphere.png.meta
@@ -29,7 +29,7 @@ TextureImporter:
   textureFormat: -3
   maxTextureSize: 2048
   textureSettings:
-    filterMode: -1
+    filterMode: 1
     aniso: 1
     mipBias: -1
     wrapMode: 1
@@ -46,7 +46,6 @@ TextureImporter:
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spritePixelsToUnits: 100
   alphaIsTransparency: 1
-  spriteTessellationDetail: -1
   textureType: 2
   buildTargetSettings: []
   spriteSheet:

--- a/Gizmos/ButtonStairs.png.meta
+++ b/Gizmos/ButtonStairs.png.meta
@@ -29,7 +29,7 @@ TextureImporter:
   textureFormat: -3
   maxTextureSize: 2048
   textureSettings:
-    filterMode: -1
+    filterMode: 1
     aniso: 1
     mipBias: -1
     wrapMode: 1
@@ -46,7 +46,6 @@ TextureImporter:
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spritePixelsToUnits: 100
   alphaIsTransparency: 1
-  spriteTessellationDetail: -1
   textureType: 2
   buildTargetSettings: []
   spriteSheet:

--- a/Gizmos/NoCSG.png.meta
+++ b/Gizmos/NoCSG.png.meta
@@ -29,7 +29,7 @@ TextureImporter:
   textureFormat: -3
   maxTextureSize: 2048
   textureSettings:
-    filterMode: 0
+    filterMode: 1
     aniso: 1
     mipBias: -1
     wrapMode: 1
@@ -46,7 +46,6 @@ TextureImporter:
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spritePixelsToUnits: 100
   alphaIsTransparency: 1
-  spriteTessellationDetail: -1
   textureType: 2
   buildTargetSettings: []
   spriteSheet:

--- a/Gizmos/ShapeEditorCreatePolygon.png.meta
+++ b/Gizmos/ShapeEditorCreatePolygon.png.meta
@@ -4,17 +4,14 @@ timeCreated: 1518385415
 licenseType: Free
 TextureImporter:
   fileIDToRecycleName: {}
-  externalObjects: {}
-  serializedVersion: 4
+  serializedVersion: 2
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
-    sRGBTexture: 0
-    linearTexture: 0
+    linearTexture: 1
+    correctGamma: 0
     fadeOut: 0
     borderMipMap: 0
-    mipMapsPreserveCoverage: 0
-    alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
     mipMapFadeDistanceEnd: 3
   bumpmap:
@@ -24,22 +21,23 @@ TextureImporter:
     normalMapFilter: 0
   isReadable: 0
   grayScaleToAlpha: 0
-  generateCubemap: 6
+  generateCubemap: 0
   cubemapConvolution: 0
+  cubemapConvolutionSteps: 7
+  cubemapConvolutionExponent: 1.5
   seamlessCubemap: 0
-  textureFormat: 1
+  textureFormat: -3
   maxTextureSize: 2048
   textureSettings:
-    serializedVersion: 2
-    filterMode: -1
+    filterMode: 1
     aniso: 1
     mipBias: -1
-    wrapU: 1
-    wrapV: 1
-    wrapW: -1
+    wrapMode: 1
   nPOTScale: 0
   lightmap: 0
+  rGBM: 0
   compressionQuality: 50
+  allowsAlphaSplitting: 0
   spriteMode: 0
   spriteExtrude: 1
   spriteMeshType: 1
@@ -47,40 +45,12 @@ TextureImporter:
   spritePivot: {x: 0.5, y: 0.5}
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spritePixelsToUnits: 100
-  alphaUsage: 1
   alphaIsTransparency: 1
-  spriteTessellationDetail: -1
   textureType: 2
-  textureShape: 1
-  maxTextureSizeSet: 0
-  compressionQualitySet: 0
-  textureFormatSet: 0
-  platformSettings:
-  - buildTarget: DefaultTexturePlatform
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 0
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
-  - buildTarget: Standalone
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 0
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
+  buildTargetSettings: []
   spriteSheet:
-    serializedVersion: 2
     sprites: []
     outline: []
-    physicsShape: []
   spritePackingTag: 
   userData: 
   assetBundleName: 

--- a/Gizmos/ShapeEditorDelete.png.meta
+++ b/Gizmos/ShapeEditorDelete.png.meta
@@ -4,17 +4,14 @@ timeCreated: 1518386878
 licenseType: Free
 TextureImporter:
   fileIDToRecycleName: {}
-  externalObjects: {}
-  serializedVersion: 4
+  serializedVersion: 2
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
-    sRGBTexture: 0
-    linearTexture: 0
+    linearTexture: 1
+    correctGamma: 0
     fadeOut: 0
     borderMipMap: 0
-    mipMapsPreserveCoverage: 0
-    alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
     mipMapFadeDistanceEnd: 3
   bumpmap:
@@ -24,22 +21,23 @@ TextureImporter:
     normalMapFilter: 0
   isReadable: 0
   grayScaleToAlpha: 0
-  generateCubemap: 6
+  generateCubemap: 0
   cubemapConvolution: 0
+  cubemapConvolutionSteps: 7
+  cubemapConvolutionExponent: 1.5
   seamlessCubemap: 0
-  textureFormat: 1
+  textureFormat: -3
   maxTextureSize: 2048
   textureSettings:
-    serializedVersion: 2
-    filterMode: -1
+    filterMode: 1
     aniso: 1
     mipBias: -1
-    wrapU: 1
-    wrapV: 1
-    wrapW: -1
+    wrapMode: 1
   nPOTScale: 0
   lightmap: 0
+  rGBM: 0
   compressionQuality: 50
+  allowsAlphaSplitting: 0
   spriteMode: 0
   spriteExtrude: 1
   spriteMeshType: 1
@@ -47,40 +45,12 @@ TextureImporter:
   spritePivot: {x: 0.5, y: 0.5}
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spritePixelsToUnits: 100
-  alphaUsage: 1
   alphaIsTransparency: 1
-  spriteTessellationDetail: -1
   textureType: 2
-  textureShape: 1
-  maxTextureSizeSet: 0
-  compressionQualitySet: 0
-  textureFormatSet: 0
-  platformSettings:
-  - buildTarget: DefaultTexturePlatform
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 0
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
-  - buildTarget: Standalone
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 0
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
+  buildTargetSettings: []
   spriteSheet:
-    serializedVersion: 2
     sprites: []
     outline: []
-    physicsShape: []
   spritePackingTag: 
   userData: 
   assetBundleName: 

--- a/Gizmos/ShapeEditorExtrudeBevel.png.meta
+++ b/Gizmos/ShapeEditorExtrudeBevel.png.meta
@@ -4,17 +4,14 @@ timeCreated: 1518385415
 licenseType: Free
 TextureImporter:
   fileIDToRecycleName: {}
-  externalObjects: {}
-  serializedVersion: 4
+  serializedVersion: 2
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
-    sRGBTexture: 0
-    linearTexture: 0
+    linearTexture: 1
+    correctGamma: 0
     fadeOut: 0
     borderMipMap: 0
-    mipMapsPreserveCoverage: 0
-    alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
     mipMapFadeDistanceEnd: 3
   bumpmap:
@@ -24,22 +21,23 @@ TextureImporter:
     normalMapFilter: 0
   isReadable: 0
   grayScaleToAlpha: 0
-  generateCubemap: 6
+  generateCubemap: 0
   cubemapConvolution: 0
+  cubemapConvolutionSteps: 7
+  cubemapConvolutionExponent: 1.5
   seamlessCubemap: 0
-  textureFormat: 1
+  textureFormat: -3
   maxTextureSize: 2048
   textureSettings:
-    serializedVersion: 2
-    filterMode: -1
+    filterMode: 1
     aniso: 1
     mipBias: -1
-    wrapU: 1
-    wrapV: 1
-    wrapW: -1
+    wrapMode: 1
   nPOTScale: 0
   lightmap: 0
+  rGBM: 0
   compressionQuality: 50
+  allowsAlphaSplitting: 0
   spriteMode: 0
   spriteExtrude: 1
   spriteMeshType: 1
@@ -47,40 +45,12 @@ TextureImporter:
   spritePivot: {x: 0.5, y: 0.5}
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spritePixelsToUnits: 100
-  alphaUsage: 1
   alphaIsTransparency: 1
-  spriteTessellationDetail: -1
   textureType: 2
-  textureShape: 1
-  maxTextureSizeSet: 0
-  compressionQualitySet: 0
-  textureFormatSet: 0
-  platformSettings:
-  - buildTarget: DefaultTexturePlatform
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 0
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
-  - buildTarget: Standalone
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 0
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
+  buildTargetSettings: []
   spriteSheet:
-    serializedVersion: 2
     sprites: []
     outline: []
-    physicsShape: []
   spritePackingTag: 
   userData: 
   assetBundleName: 

--- a/Gizmos/ShapeEditorExtrudePoint.png.meta
+++ b/Gizmos/ShapeEditorExtrudePoint.png.meta
@@ -4,17 +4,14 @@ timeCreated: 1518385415
 licenseType: Free
 TextureImporter:
   fileIDToRecycleName: {}
-  externalObjects: {}
-  serializedVersion: 4
+  serializedVersion: 2
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
-    sRGBTexture: 0
-    linearTexture: 0
+    linearTexture: 1
+    correctGamma: 0
     fadeOut: 0
     borderMipMap: 0
-    mipMapsPreserveCoverage: 0
-    alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
     mipMapFadeDistanceEnd: 3
   bumpmap:
@@ -24,22 +21,23 @@ TextureImporter:
     normalMapFilter: 0
   isReadable: 0
   grayScaleToAlpha: 0
-  generateCubemap: 6
+  generateCubemap: 0
   cubemapConvolution: 0
+  cubemapConvolutionSteps: 7
+  cubemapConvolutionExponent: 1.5
   seamlessCubemap: 0
-  textureFormat: 1
+  textureFormat: -3
   maxTextureSize: 2048
   textureSettings:
-    serializedVersion: 2
-    filterMode: -1
+    filterMode: 1
     aniso: 1
     mipBias: -1
-    wrapU: 1
-    wrapV: 1
-    wrapW: -1
+    wrapMode: 1
   nPOTScale: 0
   lightmap: 0
+  rGBM: 0
   compressionQuality: 50
+  allowsAlphaSplitting: 0
   spriteMode: 0
   spriteExtrude: 1
   spriteMeshType: 1
@@ -47,40 +45,12 @@ TextureImporter:
   spritePivot: {x: 0.5, y: 0.5}
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spritePixelsToUnits: 100
-  alphaUsage: 1
   alphaIsTransparency: 1
-  spriteTessellationDetail: -1
   textureType: 2
-  textureShape: 1
-  maxTextureSizeSet: 0
-  compressionQualitySet: 0
-  textureFormatSet: 0
-  platformSettings:
-  - buildTarget: DefaultTexturePlatform
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 0
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
-  - buildTarget: Standalone
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 0
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
+  buildTargetSettings: []
   spriteSheet:
-    serializedVersion: 2
     sprites: []
     outline: []
-    physicsShape: []
   spritePackingTag: 
   userData: 
   assetBundleName: 

--- a/Gizmos/ShapeEditorExtrudeRevolve.png.meta
+++ b/Gizmos/ShapeEditorExtrudeRevolve.png.meta
@@ -4,17 +4,14 @@ timeCreated: 1518385415
 licenseType: Free
 TextureImporter:
   fileIDToRecycleName: {}
-  externalObjects: {}
-  serializedVersion: 4
+  serializedVersion: 2
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
-    sRGBTexture: 0
-    linearTexture: 0
+    linearTexture: 1
+    correctGamma: 0
     fadeOut: 0
     borderMipMap: 0
-    mipMapsPreserveCoverage: 0
-    alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
     mipMapFadeDistanceEnd: 3
   bumpmap:
@@ -24,22 +21,23 @@ TextureImporter:
     normalMapFilter: 0
   isReadable: 0
   grayScaleToAlpha: 0
-  generateCubemap: 6
+  generateCubemap: 0
   cubemapConvolution: 0
+  cubemapConvolutionSteps: 7
+  cubemapConvolutionExponent: 1.5
   seamlessCubemap: 0
-  textureFormat: 1
+  textureFormat: -3
   maxTextureSize: 2048
   textureSettings:
-    serializedVersion: 2
-    filterMode: -1
+    filterMode: 1
     aniso: 1
     mipBias: -1
-    wrapU: 1
-    wrapV: 1
-    wrapW: -1
+    wrapMode: 1
   nPOTScale: 0
   lightmap: 0
+  rGBM: 0
   compressionQuality: 50
+  allowsAlphaSplitting: 0
   spriteMode: 0
   spriteExtrude: 1
   spriteMeshType: 1
@@ -47,40 +45,12 @@ TextureImporter:
   spritePivot: {x: 0.5, y: 0.5}
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spritePixelsToUnits: 100
-  alphaUsage: 1
   alphaIsTransparency: 1
-  spriteTessellationDetail: -1
   textureType: 2
-  textureShape: 1
-  maxTextureSizeSet: 0
-  compressionQualitySet: 0
-  textureFormatSet: 0
-  platformSettings:
-  - buildTarget: DefaultTexturePlatform
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 0
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
-  - buildTarget: Standalone
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 0
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
+  buildTargetSettings: []
   spriteSheet:
-    serializedVersion: 2
     sprites: []
     outline: []
-    physicsShape: []
   spritePackingTag: 
   userData: 
   assetBundleName: 

--- a/Gizmos/ShapeEditorExtrudeShape.png.meta
+++ b/Gizmos/ShapeEditorExtrudeShape.png.meta
@@ -4,17 +4,14 @@ timeCreated: 1518385415
 licenseType: Free
 TextureImporter:
   fileIDToRecycleName: {}
-  externalObjects: {}
-  serializedVersion: 4
+  serializedVersion: 2
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
-    sRGBTexture: 0
-    linearTexture: 0
+    linearTexture: 1
+    correctGamma: 0
     fadeOut: 0
     borderMipMap: 0
-    mipMapsPreserveCoverage: 0
-    alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
     mipMapFadeDistanceEnd: 3
   bumpmap:
@@ -24,22 +21,23 @@ TextureImporter:
     normalMapFilter: 0
   isReadable: 0
   grayScaleToAlpha: 0
-  generateCubemap: 6
+  generateCubemap: 0
   cubemapConvolution: 0
+  cubemapConvolutionSteps: 7
+  cubemapConvolutionExponent: 1.5
   seamlessCubemap: 0
-  textureFormat: 1
+  textureFormat: -3
   maxTextureSize: 2048
   textureSettings:
-    serializedVersion: 2
-    filterMode: -1
+    filterMode: 1
     aniso: 1
     mipBias: -1
-    wrapU: 1
-    wrapV: 1
-    wrapW: -1
+    wrapMode: 1
   nPOTScale: 0
   lightmap: 0
+  rGBM: 0
   compressionQuality: 50
+  allowsAlphaSplitting: 0
   spriteMode: 0
   spriteExtrude: 1
   spriteMeshType: 1
@@ -47,40 +45,12 @@ TextureImporter:
   spritePivot: {x: 0.5, y: 0.5}
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spritePixelsToUnits: 100
-  alphaUsage: 1
   alphaIsTransparency: 1
-  spriteTessellationDetail: -1
   textureType: 2
-  textureShape: 1
-  maxTextureSizeSet: 0
-  compressionQualitySet: 0
-  textureFormatSet: 0
-  platformSettings:
-  - buildTarget: DefaultTexturePlatform
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 0
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
-  - buildTarget: Standalone
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 0
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
+  buildTargetSettings: []
   spriteSheet:
-    serializedVersion: 2
     sprites: []
     outline: []
-    physicsShape: []
   spritePackingTag: 
   userData: 
   assetBundleName: 

--- a/Gizmos/ShapeEditorFlipHorizontally.png.meta
+++ b/Gizmos/ShapeEditorFlipHorizontally.png.meta
@@ -4,17 +4,14 @@ timeCreated: 1518386878
 licenseType: Free
 TextureImporter:
   fileIDToRecycleName: {}
-  externalObjects: {}
-  serializedVersion: 4
+  serializedVersion: 2
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
-    sRGBTexture: 0
-    linearTexture: 0
+    linearTexture: 1
+    correctGamma: 0
     fadeOut: 0
     borderMipMap: 0
-    mipMapsPreserveCoverage: 0
-    alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
     mipMapFadeDistanceEnd: 3
   bumpmap:
@@ -24,22 +21,23 @@ TextureImporter:
     normalMapFilter: 0
   isReadable: 0
   grayScaleToAlpha: 0
-  generateCubemap: 6
+  generateCubemap: 0
   cubemapConvolution: 0
+  cubemapConvolutionSteps: 7
+  cubemapConvolutionExponent: 1.5
   seamlessCubemap: 0
-  textureFormat: 1
+  textureFormat: -3
   maxTextureSize: 2048
   textureSettings:
-    serializedVersion: 2
-    filterMode: -1
+    filterMode: 1
     aniso: 1
     mipBias: -1
-    wrapU: 1
-    wrapV: 1
-    wrapW: -1
+    wrapMode: 1
   nPOTScale: 0
   lightmap: 0
+  rGBM: 0
   compressionQuality: 50
+  allowsAlphaSplitting: 0
   spriteMode: 0
   spriteExtrude: 1
   spriteMeshType: 1
@@ -47,40 +45,12 @@ TextureImporter:
   spritePivot: {x: 0.5, y: 0.5}
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spritePixelsToUnits: 100
-  alphaUsage: 1
   alphaIsTransparency: 1
-  spriteTessellationDetail: -1
   textureType: 2
-  textureShape: 1
-  maxTextureSizeSet: 0
-  compressionQualitySet: 0
-  textureFormatSet: 0
-  platformSettings:
-  - buildTarget: DefaultTexturePlatform
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 0
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
-  - buildTarget: Standalone
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 0
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
+  buildTargetSettings: []
   spriteSheet:
-    serializedVersion: 2
     sprites: []
     outline: []
-    physicsShape: []
   spritePackingTag: 
   userData: 
   assetBundleName: 

--- a/Gizmos/ShapeEditorFlipVertically.png.meta
+++ b/Gizmos/ShapeEditorFlipVertically.png.meta
@@ -4,17 +4,14 @@ timeCreated: 1518386878
 licenseType: Free
 TextureImporter:
   fileIDToRecycleName: {}
-  externalObjects: {}
-  serializedVersion: 4
+  serializedVersion: 2
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
-    sRGBTexture: 0
-    linearTexture: 0
+    linearTexture: 1
+    correctGamma: 0
     fadeOut: 0
     borderMipMap: 0
-    mipMapsPreserveCoverage: 0
-    alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
     mipMapFadeDistanceEnd: 3
   bumpmap:
@@ -24,22 +21,23 @@ TextureImporter:
     normalMapFilter: 0
   isReadable: 0
   grayScaleToAlpha: 0
-  generateCubemap: 6
+  generateCubemap: 0
   cubemapConvolution: 0
+  cubemapConvolutionSteps: 7
+  cubemapConvolutionExponent: 1.5
   seamlessCubemap: 0
-  textureFormat: 1
+  textureFormat: -3
   maxTextureSize: 2048
   textureSettings:
-    serializedVersion: 2
-    filterMode: -1
+    filterMode: 1
     aniso: 1
     mipBias: -1
-    wrapU: 1
-    wrapV: 1
-    wrapW: -1
+    wrapMode: 1
   nPOTScale: 0
   lightmap: 0
+  rGBM: 0
   compressionQuality: 50
+  allowsAlphaSplitting: 0
   spriteMode: 0
   spriteExtrude: 1
   spriteMeshType: 1
@@ -47,40 +45,12 @@ TextureImporter:
   spritePivot: {x: 0.5, y: 0.5}
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spritePixelsToUnits: 100
-  alphaUsage: 1
   alphaIsTransparency: 1
-  spriteTessellationDetail: -1
   textureType: 2
-  textureShape: 1
-  maxTextureSizeSet: 0
-  compressionQualitySet: 0
-  textureFormatSet: 0
-  platformSettings:
-  - buildTarget: DefaultTexturePlatform
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 0
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
-  - buildTarget: Standalone
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 0
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
+  buildTargetSettings: []
   spriteSheet:
-    serializedVersion: 2
     sprites: []
     outline: []
-    physicsShape: []
   spritePackingTag: 
   userData: 
   assetBundleName: 

--- a/Gizmos/ShapeEditorHome.png.meta
+++ b/Gizmos/ShapeEditorHome.png.meta
@@ -4,17 +4,14 @@ timeCreated: 1518723652
 licenseType: Free
 TextureImporter:
   fileIDToRecycleName: {}
-  externalObjects: {}
-  serializedVersion: 4
+  serializedVersion: 2
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
-    sRGBTexture: 0
-    linearTexture: 0
+    linearTexture: 1
+    correctGamma: 0
     fadeOut: 0
     borderMipMap: 0
-    mipMapsPreserveCoverage: 0
-    alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
     mipMapFadeDistanceEnd: 3
   bumpmap:
@@ -24,22 +21,23 @@ TextureImporter:
     normalMapFilter: 0
   isReadable: 0
   grayScaleToAlpha: 0
-  generateCubemap: 6
+  generateCubemap: 0
   cubemapConvolution: 0
+  cubemapConvolutionSteps: 7
+  cubemapConvolutionExponent: 1.5
   seamlessCubemap: 0
-  textureFormat: 1
+  textureFormat: -3
   maxTextureSize: 2048
   textureSettings:
-    serializedVersion: 2
-    filterMode: -1
+    filterMode: 1
     aniso: 1
     mipBias: -1
-    wrapU: 1
-    wrapV: 1
-    wrapW: -1
+    wrapMode: 1
   nPOTScale: 0
   lightmap: 0
+  rGBM: 0
   compressionQuality: 50
+  allowsAlphaSplitting: 0
   spriteMode: 0
   spriteExtrude: 1
   spriteMeshType: 1
@@ -47,40 +45,12 @@ TextureImporter:
   spritePivot: {x: 0.5, y: 0.5}
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spritePixelsToUnits: 100
-  alphaUsage: 1
   alphaIsTransparency: 1
-  spriteTessellationDetail: -1
   textureType: 2
-  textureShape: 1
-  maxTextureSizeSet: 0
-  compressionQualitySet: 0
-  textureFormatSet: 0
-  platformSettings:
-  - buildTarget: DefaultTexturePlatform
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 0
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
-  - buildTarget: Standalone
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 0
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
+  buildTargetSettings: []
   spriteSheet:
-    serializedVersion: 2
     sprites: []
     outline: []
-    physicsShape: []
   spritePackingTag: 
   userData: 
   assetBundleName: 

--- a/Gizmos/ShapeEditorNew.png.meta
+++ b/Gizmos/ShapeEditorNew.png.meta
@@ -4,17 +4,14 @@ timeCreated: 1518386878
 licenseType: Free
 TextureImporter:
   fileIDToRecycleName: {}
-  externalObjects: {}
-  serializedVersion: 4
+  serializedVersion: 2
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
-    sRGBTexture: 0
-    linearTexture: 0
+    linearTexture: 1
+    correctGamma: 0
     fadeOut: 0
     borderMipMap: 0
-    mipMapsPreserveCoverage: 0
-    alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
     mipMapFadeDistanceEnd: 3
   bumpmap:
@@ -24,22 +21,23 @@ TextureImporter:
     normalMapFilter: 0
   isReadable: 0
   grayScaleToAlpha: 0
-  generateCubemap: 6
+  generateCubemap: 0
   cubemapConvolution: 0
+  cubemapConvolutionSteps: 7
+  cubemapConvolutionExponent: 1.5
   seamlessCubemap: 0
-  textureFormat: 1
+  textureFormat: -3
   maxTextureSize: 2048
   textureSettings:
-    serializedVersion: 2
-    filterMode: -1
+    filterMode: 1
     aniso: 1
     mipBias: -1
-    wrapU: 1
-    wrapV: 1
-    wrapW: -1
+    wrapMode: 1
   nPOTScale: 0
   lightmap: 0
+  rGBM: 0
   compressionQuality: 50
+  allowsAlphaSplitting: 0
   spriteMode: 0
   spriteExtrude: 1
   spriteMeshType: 1
@@ -47,40 +45,12 @@ TextureImporter:
   spritePivot: {x: 0.5, y: 0.5}
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spritePixelsToUnits: 100
-  alphaUsage: 1
   alphaIsTransparency: 1
-  spriteTessellationDetail: -1
   textureType: 2
-  textureShape: 1
-  maxTextureSizeSet: 0
-  compressionQualitySet: 0
-  textureFormatSet: 0
-  platformSettings:
-  - buildTarget: DefaultTexturePlatform
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 0
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
-  - buildTarget: Standalone
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 0
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
+  buildTargetSettings: []
   spriteSheet:
-    serializedVersion: 2
     sprites: []
     outline: []
-    physicsShape: []
   spritePackingTag: 
   userData: 
   assetBundleName: 

--- a/Gizmos/ShapeEditorOpen.png.meta
+++ b/Gizmos/ShapeEditorOpen.png.meta
@@ -4,17 +4,14 @@ timeCreated: 1518386878
 licenseType: Free
 TextureImporter:
   fileIDToRecycleName: {}
-  externalObjects: {}
-  serializedVersion: 4
+  serializedVersion: 2
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
-    sRGBTexture: 0
-    linearTexture: 0
+    linearTexture: 1
+    correctGamma: 0
     fadeOut: 0
     borderMipMap: 0
-    mipMapsPreserveCoverage: 0
-    alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
     mipMapFadeDistanceEnd: 3
   bumpmap:
@@ -24,22 +21,23 @@ TextureImporter:
     normalMapFilter: 0
   isReadable: 0
   grayScaleToAlpha: 0
-  generateCubemap: 6
+  generateCubemap: 0
   cubemapConvolution: 0
+  cubemapConvolutionSteps: 7
+  cubemapConvolutionExponent: 1.5
   seamlessCubemap: 0
-  textureFormat: 1
+  textureFormat: -3
   maxTextureSize: 2048
   textureSettings:
-    serializedVersion: 2
-    filterMode: -1
+    filterMode: 1
     aniso: 1
     mipBias: -1
-    wrapU: 1
-    wrapV: 1
-    wrapW: -1
+    wrapMode: 1
   nPOTScale: 0
   lightmap: 0
+  rGBM: 0
   compressionQuality: 50
+  allowsAlphaSplitting: 0
   spriteMode: 0
   spriteExtrude: 1
   spriteMeshType: 1
@@ -47,40 +45,12 @@ TextureImporter:
   spritePivot: {x: 0.5, y: 0.5}
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spritePixelsToUnits: 100
-  alphaUsage: 1
   alphaIsTransparency: 1
-  spriteTessellationDetail: -1
   textureType: 2
-  textureShape: 1
-  maxTextureSizeSet: 0
-  compressionQualitySet: 0
-  textureFormatSet: 0
-  platformSettings:
-  - buildTarget: DefaultTexturePlatform
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 0
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
-  - buildTarget: Standalone
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 0
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
+  buildTargetSettings: []
   spriteSheet:
-    serializedVersion: 2
     sprites: []
     outline: []
-    physicsShape: []
   spritePackingTag: 
   userData: 
   assetBundleName: 

--- a/Gizmos/ShapeEditorRotate90Left.png.meta
+++ b/Gizmos/ShapeEditorRotate90Left.png.meta
@@ -4,17 +4,14 @@ timeCreated: 1518440229
 licenseType: Free
 TextureImporter:
   fileIDToRecycleName: {}
-  externalObjects: {}
-  serializedVersion: 4
+  serializedVersion: 2
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
-    sRGBTexture: 0
-    linearTexture: 0
+    linearTexture: 1
+    correctGamma: 0
     fadeOut: 0
     borderMipMap: 0
-    mipMapsPreserveCoverage: 0
-    alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
     mipMapFadeDistanceEnd: 3
   bumpmap:
@@ -24,22 +21,23 @@ TextureImporter:
     normalMapFilter: 0
   isReadable: 0
   grayScaleToAlpha: 0
-  generateCubemap: 6
+  generateCubemap: 0
   cubemapConvolution: 0
+  cubemapConvolutionSteps: 7
+  cubemapConvolutionExponent: 1.5
   seamlessCubemap: 0
-  textureFormat: 1
+  textureFormat: -3
   maxTextureSize: 2048
   textureSettings:
-    serializedVersion: 2
-    filterMode: -1
+    filterMode: 1
     aniso: 1
     mipBias: -1
-    wrapU: 1
-    wrapV: 1
-    wrapW: -1
+    wrapMode: 1
   nPOTScale: 0
   lightmap: 0
+  rGBM: 0
   compressionQuality: 50
+  allowsAlphaSplitting: 0
   spriteMode: 0
   spriteExtrude: 1
   spriteMeshType: 1
@@ -47,40 +45,12 @@ TextureImporter:
   spritePivot: {x: 0.5, y: 0.5}
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spritePixelsToUnits: 100
-  alphaUsage: 1
   alphaIsTransparency: 1
-  spriteTessellationDetail: -1
   textureType: 2
-  textureShape: 1
-  maxTextureSizeSet: 0
-  compressionQualitySet: 0
-  textureFormatSet: 0
-  platformSettings:
-  - buildTarget: DefaultTexturePlatform
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 0
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
-  - buildTarget: Standalone
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 0
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
+  buildTargetSettings: []
   spriteSheet:
-    serializedVersion: 2
     sprites: []
     outline: []
-    physicsShape: []
   spritePackingTag: 
   userData: 
   assetBundleName: 

--- a/Gizmos/ShapeEditorRotate90Right.png.meta
+++ b/Gizmos/ShapeEditorRotate90Right.png.meta
@@ -4,17 +4,14 @@ timeCreated: 1518440229
 licenseType: Free
 TextureImporter:
   fileIDToRecycleName: {}
-  externalObjects: {}
-  serializedVersion: 4
+  serializedVersion: 2
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
-    sRGBTexture: 0
-    linearTexture: 0
+    linearTexture: 1
+    correctGamma: 0
     fadeOut: 0
     borderMipMap: 0
-    mipMapsPreserveCoverage: 0
-    alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
     mipMapFadeDistanceEnd: 3
   bumpmap:
@@ -24,22 +21,23 @@ TextureImporter:
     normalMapFilter: 0
   isReadable: 0
   grayScaleToAlpha: 0
-  generateCubemap: 6
+  generateCubemap: 0
   cubemapConvolution: 0
+  cubemapConvolutionSteps: 7
+  cubemapConvolutionExponent: 1.5
   seamlessCubemap: 0
-  textureFormat: 1
+  textureFormat: -3
   maxTextureSize: 2048
   textureSettings:
-    serializedVersion: 2
-    filterMode: -1
+    filterMode: 1
     aniso: 1
     mipBias: -1
-    wrapU: 1
-    wrapV: 1
-    wrapW: -1
+    wrapMode: 1
   nPOTScale: 0
   lightmap: 0
+  rGBM: 0
   compressionQuality: 50
+  allowsAlphaSplitting: 0
   spriteMode: 0
   spriteExtrude: 1
   spriteMeshType: 1
@@ -47,40 +45,12 @@ TextureImporter:
   spritePivot: {x: 0.5, y: 0.5}
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spritePixelsToUnits: 100
-  alphaUsage: 1
   alphaIsTransparency: 1
-  spriteTessellationDetail: -1
   textureType: 2
-  textureShape: 1
-  maxTextureSizeSet: 0
-  compressionQualitySet: 0
-  textureFormatSet: 0
-  platformSettings:
-  - buildTarget: DefaultTexturePlatform
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 0
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
-  - buildTarget: Standalone
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 0
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
+  buildTargetSettings: []
   spriteSheet:
-    serializedVersion: 2
     sprites: []
     outline: []
-    physicsShape: []
   spritePackingTag: 
   userData: 
   assetBundleName: 

--- a/Gizmos/ShapeEditorSave.png.meta
+++ b/Gizmos/ShapeEditorSave.png.meta
@@ -4,17 +4,14 @@ timeCreated: 1518386878
 licenseType: Free
 TextureImporter:
   fileIDToRecycleName: {}
-  externalObjects: {}
-  serializedVersion: 4
+  serializedVersion: 2
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
-    sRGBTexture: 0
-    linearTexture: 0
+    linearTexture: 1
+    correctGamma: 0
     fadeOut: 0
     borderMipMap: 0
-    mipMapsPreserveCoverage: 0
-    alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
     mipMapFadeDistanceEnd: 3
   bumpmap:
@@ -24,22 +21,23 @@ TextureImporter:
     normalMapFilter: 0
   isReadable: 0
   grayScaleToAlpha: 0
-  generateCubemap: 6
+  generateCubemap: 0
   cubemapConvolution: 0
+  cubemapConvolutionSteps: 7
+  cubemapConvolutionExponent: 1.5
   seamlessCubemap: 0
-  textureFormat: 1
+  textureFormat: -3
   maxTextureSize: 2048
   textureSettings:
-    serializedVersion: 2
-    filterMode: -1
+    filterMode: 1
     aniso: 1
     mipBias: -1
-    wrapU: 1
-    wrapV: 1
-    wrapW: -1
+    wrapMode: 1
   nPOTScale: 0
   lightmap: 0
+  rGBM: 0
   compressionQuality: 50
+  allowsAlphaSplitting: 0
   spriteMode: 0
   spriteExtrude: 1
   spriteMeshType: 1
@@ -47,40 +45,12 @@ TextureImporter:
   spritePivot: {x: 0.5, y: 0.5}
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spritePixelsToUnits: 100
-  alphaUsage: 1
   alphaIsTransparency: 1
-  spriteTessellationDetail: -1
   textureType: 2
-  textureShape: 1
-  maxTextureSizeSet: 0
-  compressionQualitySet: 0
-  textureFormatSet: 0
-  platformSettings:
-  - buildTarget: DefaultTexturePlatform
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 0
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
-  - buildTarget: Standalone
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 0
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
+  buildTargetSettings: []
   spriteSheet:
-    serializedVersion: 2
     sprites: []
     outline: []
-    physicsShape: []
   spritePackingTag: 
   userData: 
   assetBundleName: 

--- a/Gizmos/ShapeEditorSegmentBezier.png.meta
+++ b/Gizmos/ShapeEditorSegmentBezier.png.meta
@@ -4,17 +4,14 @@ timeCreated: 1518385415
 licenseType: Free
 TextureImporter:
   fileIDToRecycleName: {}
-  externalObjects: {}
-  serializedVersion: 4
+  serializedVersion: 2
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
-    sRGBTexture: 0
-    linearTexture: 0
+    linearTexture: 1
+    correctGamma: 0
     fadeOut: 0
     borderMipMap: 0
-    mipMapsPreserveCoverage: 0
-    alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
     mipMapFadeDistanceEnd: 3
   bumpmap:
@@ -24,22 +21,23 @@ TextureImporter:
     normalMapFilter: 0
   isReadable: 0
   grayScaleToAlpha: 0
-  generateCubemap: 6
+  generateCubemap: 0
   cubemapConvolution: 0
+  cubemapConvolutionSteps: 7
+  cubemapConvolutionExponent: 1.5
   seamlessCubemap: 0
-  textureFormat: 1
+  textureFormat: -3
   maxTextureSize: 2048
   textureSettings:
-    serializedVersion: 2
-    filterMode: -1
+    filterMode: 1
     aniso: 1
     mipBias: -1
-    wrapU: 1
-    wrapV: 1
-    wrapW: -1
+    wrapMode: 1
   nPOTScale: 0
   lightmap: 0
+  rGBM: 0
   compressionQuality: 50
+  allowsAlphaSplitting: 0
   spriteMode: 0
   spriteExtrude: 1
   spriteMeshType: 1
@@ -47,40 +45,12 @@ TextureImporter:
   spritePivot: {x: 0.5, y: 0.5}
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spritePixelsToUnits: 100
-  alphaUsage: 1
   alphaIsTransparency: 1
-  spriteTessellationDetail: -1
   textureType: 2
-  textureShape: 1
-  maxTextureSizeSet: 0
-  compressionQualitySet: 0
-  textureFormatSet: 0
-  platformSettings:
-  - buildTarget: DefaultTexturePlatform
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 0
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
-  - buildTarget: Standalone
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 0
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
+  buildTargetSettings: []
   spriteSheet:
-    serializedVersion: 2
     sprites: []
     outline: []
-    physicsShape: []
   spritePackingTag: 
   userData: 
   assetBundleName: 

--- a/Gizmos/ShapeEditorSegmentBezierDetail.png.meta
+++ b/Gizmos/ShapeEditorSegmentBezierDetail.png.meta
@@ -4,17 +4,14 @@ timeCreated: 1518467959
 licenseType: Free
 TextureImporter:
   fileIDToRecycleName: {}
-  externalObjects: {}
-  serializedVersion: 4
+  serializedVersion: 2
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
-    sRGBTexture: 0
-    linearTexture: 0
+    linearTexture: 1
+    correctGamma: 0
     fadeOut: 0
     borderMipMap: 0
-    mipMapsPreserveCoverage: 0
-    alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
     mipMapFadeDistanceEnd: 3
   bumpmap:
@@ -24,22 +21,23 @@ TextureImporter:
     normalMapFilter: 0
   isReadable: 0
   grayScaleToAlpha: 0
-  generateCubemap: 6
+  generateCubemap: 0
   cubemapConvolution: 0
+  cubemapConvolutionSteps: 7
+  cubemapConvolutionExponent: 1.5
   seamlessCubemap: 0
-  textureFormat: 1
+  textureFormat: -3
   maxTextureSize: 2048
   textureSettings:
-    serializedVersion: 2
-    filterMode: -1
+    filterMode: 1
     aniso: 1
     mipBias: -1
-    wrapU: 1
-    wrapV: 1
-    wrapW: -1
+    wrapMode: 1
   nPOTScale: 0
   lightmap: 0
+  rGBM: 0
   compressionQuality: 50
+  allowsAlphaSplitting: 0
   spriteMode: 0
   spriteExtrude: 1
   spriteMeshType: 1
@@ -47,40 +45,12 @@ TextureImporter:
   spritePivot: {x: 0.5, y: 0.5}
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spritePixelsToUnits: 100
-  alphaUsage: 1
   alphaIsTransparency: 1
-  spriteTessellationDetail: -1
   textureType: 2
-  textureShape: 1
-  maxTextureSizeSet: 0
-  compressionQualitySet: 0
-  textureFormatSet: 0
-  platformSettings:
-  - buildTarget: DefaultTexturePlatform
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 0
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
-  - buildTarget: Standalone
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 0
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
+  buildTargetSettings: []
   spriteSheet:
-    serializedVersion: 2
     sprites: []
     outline: []
-    physicsShape: []
   spritePackingTag: 
   userData: 
   assetBundleName: 

--- a/Gizmos/ShapeEditorSegmentInsert.png.meta
+++ b/Gizmos/ShapeEditorSegmentInsert.png.meta
@@ -4,17 +4,14 @@ timeCreated: 1518386878
 licenseType: Free
 TextureImporter:
   fileIDToRecycleName: {}
-  externalObjects: {}
-  serializedVersion: 4
+  serializedVersion: 2
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
-    sRGBTexture: 0
-    linearTexture: 0
+    linearTexture: 1
+    correctGamma: 0
     fadeOut: 0
     borderMipMap: 0
-    mipMapsPreserveCoverage: 0
-    alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
     mipMapFadeDistanceEnd: 3
   bumpmap:
@@ -24,22 +21,23 @@ TextureImporter:
     normalMapFilter: 0
   isReadable: 0
   grayScaleToAlpha: 0
-  generateCubemap: 6
+  generateCubemap: 0
   cubemapConvolution: 0
+  cubemapConvolutionSteps: 7
+  cubemapConvolutionExponent: 1.5
   seamlessCubemap: 0
-  textureFormat: 1
+  textureFormat: -3
   maxTextureSize: 2048
   textureSettings:
-    serializedVersion: 2
-    filterMode: -1
+    filterMode: 1
     aniso: 1
     mipBias: -1
-    wrapU: 1
-    wrapV: 1
-    wrapW: -1
+    wrapMode: 1
   nPOTScale: 0
   lightmap: 0
+  rGBM: 0
   compressionQuality: 50
+  allowsAlphaSplitting: 0
   spriteMode: 0
   spriteExtrude: 1
   spriteMeshType: 1
@@ -47,40 +45,12 @@ TextureImporter:
   spritePivot: {x: 0.5, y: 0.5}
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spritePixelsToUnits: 100
-  alphaUsage: 1
   alphaIsTransparency: 1
-  spriteTessellationDetail: -1
   textureType: 2
-  textureShape: 1
-  maxTextureSizeSet: 0
-  compressionQualitySet: 0
-  textureFormatSet: 0
-  platformSettings:
-  - buildTarget: DefaultTexturePlatform
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 0
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
-  - buildTarget: Standalone
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 0
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
+  buildTargetSettings: []
   spriteSheet:
-    serializedVersion: 2
     sprites: []
     outline: []
-    physicsShape: []
   spritePackingTag: 
   userData: 
   assetBundleName: 

--- a/Gizmos/ShapeEditorSegmentLinear.png.meta
+++ b/Gizmos/ShapeEditorSegmentLinear.png.meta
@@ -4,17 +4,14 @@ timeCreated: 1518385415
 licenseType: Free
 TextureImporter:
   fileIDToRecycleName: {}
-  externalObjects: {}
-  serializedVersion: 4
+  serializedVersion: 2
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
-    sRGBTexture: 0
-    linearTexture: 0
+    linearTexture: 1
+    correctGamma: 0
     fadeOut: 0
     borderMipMap: 0
-    mipMapsPreserveCoverage: 0
-    alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
     mipMapFadeDistanceEnd: 3
   bumpmap:
@@ -24,22 +21,23 @@ TextureImporter:
     normalMapFilter: 0
   isReadable: 0
   grayScaleToAlpha: 0
-  generateCubemap: 6
+  generateCubemap: 0
   cubemapConvolution: 0
+  cubemapConvolutionSteps: 7
+  cubemapConvolutionExponent: 1.5
   seamlessCubemap: 0
-  textureFormat: 1
+  textureFormat: -3
   maxTextureSize: 2048
   textureSettings:
-    serializedVersion: 2
-    filterMode: -1
+    filterMode: 1
     aniso: 1
     mipBias: -1
-    wrapU: 1
-    wrapV: 1
-    wrapW: -1
+    wrapMode: 1
   nPOTScale: 0
   lightmap: 0
+  rGBM: 0
   compressionQuality: 50
+  allowsAlphaSplitting: 0
   spriteMode: 0
   spriteExtrude: 1
   spriteMeshType: 1
@@ -47,40 +45,12 @@ TextureImporter:
   spritePivot: {x: 0.5, y: 0.5}
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spritePixelsToUnits: 100
-  alphaUsage: 1
   alphaIsTransparency: 1
-  spriteTessellationDetail: -1
   textureType: 2
-  textureShape: 1
-  maxTextureSizeSet: 0
-  compressionQualitySet: 0
-  textureFormatSet: 0
-  platformSettings:
-  - buildTarget: DefaultTexturePlatform
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 0
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
-  - buildTarget: Standalone
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 0
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
+  buildTargetSettings: []
   spriteSheet:
-    serializedVersion: 2
     sprites: []
     outline: []
-    physicsShape: []
   spritePackingTag: 
   userData: 
   assetBundleName: 

--- a/Gizmos/ShapeEditorShapeCreate.png.meta
+++ b/Gizmos/ShapeEditorShapeCreate.png.meta
@@ -4,17 +4,14 @@ timeCreated: 1518453820
 licenseType: Free
 TextureImporter:
   fileIDToRecycleName: {}
-  externalObjects: {}
-  serializedVersion: 4
+  serializedVersion: 2
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
-    sRGBTexture: 0
-    linearTexture: 0
+    linearTexture: 1
+    correctGamma: 0
     fadeOut: 0
     borderMipMap: 0
-    mipMapsPreserveCoverage: 0
-    alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
     mipMapFadeDistanceEnd: 3
   bumpmap:
@@ -24,22 +21,23 @@ TextureImporter:
     normalMapFilter: 0
   isReadable: 0
   grayScaleToAlpha: 0
-  generateCubemap: 6
+  generateCubemap: 0
   cubemapConvolution: 0
+  cubemapConvolutionSteps: 7
+  cubemapConvolutionExponent: 1.5
   seamlessCubemap: 0
-  textureFormat: 1
+  textureFormat: -3
   maxTextureSize: 2048
   textureSettings:
-    serializedVersion: 2
-    filterMode: -1
+    filterMode: 1
     aniso: 1
     mipBias: -1
-    wrapU: 1
-    wrapV: 1
-    wrapW: -1
+    wrapMode: 1
   nPOTScale: 0
   lightmap: 0
+  rGBM: 0
   compressionQuality: 50
+  allowsAlphaSplitting: 0
   spriteMode: 0
   spriteExtrude: 1
   spriteMeshType: 1
@@ -47,40 +45,12 @@ TextureImporter:
   spritePivot: {x: 0.5, y: 0.5}
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spritePixelsToUnits: 100
-  alphaUsage: 1
   alphaIsTransparency: 1
-  spriteTessellationDetail: -1
   textureType: 2
-  textureShape: 1
-  maxTextureSizeSet: 0
-  compressionQualitySet: 0
-  textureFormatSet: 0
-  platformSettings:
-  - buildTarget: DefaultTexturePlatform
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 0
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
-  - buildTarget: Standalone
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 0
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
+  buildTargetSettings: []
   spriteSheet:
-    serializedVersion: 2
     sprites: []
     outline: []
-    physicsShape: []
   spritePackingTag: 
   userData: 
   assetBundleName: 

--- a/Gizmos/ShapeEditorShapeDuplicate.png.meta
+++ b/Gizmos/ShapeEditorShapeDuplicate.png.meta
@@ -4,17 +4,14 @@ timeCreated: 1518953319
 licenseType: Free
 TextureImporter:
   fileIDToRecycleName: {}
-  externalObjects: {}
-  serializedVersion: 4
+  serializedVersion: 2
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
-    sRGBTexture: 0
-    linearTexture: 0
+    linearTexture: 1
+    correctGamma: 0
     fadeOut: 0
     borderMipMap: 0
-    mipMapsPreserveCoverage: 0
-    alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
     mipMapFadeDistanceEnd: 3
   bumpmap:
@@ -24,22 +21,23 @@ TextureImporter:
     normalMapFilter: 0
   isReadable: 0
   grayScaleToAlpha: 0
-  generateCubemap: 6
+  generateCubemap: 0
   cubemapConvolution: 0
+  cubemapConvolutionSteps: 7
+  cubemapConvolutionExponent: 1.5
   seamlessCubemap: 0
-  textureFormat: 1
+  textureFormat: -3
   maxTextureSize: 2048
   textureSettings:
-    serializedVersion: 2
-    filterMode: -1
+    filterMode: 1
     aniso: 1
     mipBias: -1
-    wrapU: 1
-    wrapV: 1
-    wrapW: -1
+    wrapMode: 1
   nPOTScale: 0
   lightmap: 0
+  rGBM: 0
   compressionQuality: 50
+  allowsAlphaSplitting: 0
   spriteMode: 0
   spriteExtrude: 1
   spriteMeshType: 1
@@ -47,40 +45,12 @@ TextureImporter:
   spritePivot: {x: 0.5, y: 0.5}
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spritePixelsToUnits: 100
-  alphaUsage: 1
   alphaIsTransparency: 1
-  spriteTessellationDetail: -1
   textureType: 2
-  textureShape: 1
-  maxTextureSizeSet: 0
-  compressionQualitySet: 0
-  textureFormatSet: 0
-  platformSettings:
-  - buildTarget: DefaultTexturePlatform
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 0
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
-  - buildTarget: Standalone
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 0
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
+  buildTargetSettings: []
   spriteSheet:
-    serializedVersion: 2
     sprites: []
     outline: []
-    physicsShape: []
   spritePackingTag: 
   userData: 
   assetBundleName: 

--- a/Gizmos/ShapeEditorZoomIn.png.meta
+++ b/Gizmos/ShapeEditorZoomIn.png.meta
@@ -4,17 +4,14 @@ timeCreated: 1518386878
 licenseType: Free
 TextureImporter:
   fileIDToRecycleName: {}
-  externalObjects: {}
-  serializedVersion: 4
+  serializedVersion: 2
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
-    sRGBTexture: 0
-    linearTexture: 0
+    linearTexture: 1
+    correctGamma: 0
     fadeOut: 0
     borderMipMap: 0
-    mipMapsPreserveCoverage: 0
-    alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
     mipMapFadeDistanceEnd: 3
   bumpmap:
@@ -24,22 +21,23 @@ TextureImporter:
     normalMapFilter: 0
   isReadable: 0
   grayScaleToAlpha: 0
-  generateCubemap: 6
+  generateCubemap: 0
   cubemapConvolution: 0
+  cubemapConvolutionSteps: 7
+  cubemapConvolutionExponent: 1.5
   seamlessCubemap: 0
-  textureFormat: 1
+  textureFormat: -3
   maxTextureSize: 2048
   textureSettings:
-    serializedVersion: 2
-    filterMode: -1
+    filterMode: 1
     aniso: 1
     mipBias: -1
-    wrapU: 1
-    wrapV: 1
-    wrapW: -1
+    wrapMode: 1
   nPOTScale: 0
   lightmap: 0
+  rGBM: 0
   compressionQuality: 50
+  allowsAlphaSplitting: 0
   spriteMode: 0
   spriteExtrude: 1
   spriteMeshType: 1
@@ -47,40 +45,12 @@ TextureImporter:
   spritePivot: {x: 0.5, y: 0.5}
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spritePixelsToUnits: 100
-  alphaUsage: 1
   alphaIsTransparency: 1
-  spriteTessellationDetail: -1
   textureType: 2
-  textureShape: 1
-  maxTextureSizeSet: 0
-  compressionQualitySet: 0
-  textureFormatSet: 0
-  platformSettings:
-  - buildTarget: DefaultTexturePlatform
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 0
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
-  - buildTarget: Standalone
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 0
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
+  buildTargetSettings: []
   spriteSheet:
-    serializedVersion: 2
     sprites: []
     outline: []
-    physicsShape: []
   spritePackingTag: 
   userData: 
   assetBundleName: 

--- a/Gizmos/ShapeEditorZoomOut.png.meta
+++ b/Gizmos/ShapeEditorZoomOut.png.meta
@@ -4,17 +4,14 @@ timeCreated: 1518386878
 licenseType: Free
 TextureImporter:
   fileIDToRecycleName: {}
-  externalObjects: {}
-  serializedVersion: 4
+  serializedVersion: 2
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
-    sRGBTexture: 0
-    linearTexture: 0
+    linearTexture: 1
+    correctGamma: 0
     fadeOut: 0
     borderMipMap: 0
-    mipMapsPreserveCoverage: 0
-    alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
     mipMapFadeDistanceEnd: 3
   bumpmap:
@@ -24,22 +21,23 @@ TextureImporter:
     normalMapFilter: 0
   isReadable: 0
   grayScaleToAlpha: 0
-  generateCubemap: 6
+  generateCubemap: 0
   cubemapConvolution: 0
+  cubemapConvolutionSteps: 7
+  cubemapConvolutionExponent: 1.5
   seamlessCubemap: 0
-  textureFormat: 1
+  textureFormat: -3
   maxTextureSize: 2048
   textureSettings:
-    serializedVersion: 2
-    filterMode: -1
+    filterMode: 1
     aniso: 1
     mipBias: -1
-    wrapU: 1
-    wrapV: 1
-    wrapW: -1
+    wrapMode: 1
   nPOTScale: 0
   lightmap: 0
+  rGBM: 0
   compressionQuality: 50
+  allowsAlphaSplitting: 0
   spriteMode: 0
   spriteExtrude: 1
   spriteMeshType: 1
@@ -47,40 +45,12 @@ TextureImporter:
   spritePivot: {x: 0.5, y: 0.5}
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spritePixelsToUnits: 100
-  alphaUsage: 1
   alphaIsTransparency: 1
-  spriteTessellationDetail: -1
   textureType: 2
-  textureShape: 1
-  maxTextureSizeSet: 0
-  compressionQualitySet: 0
-  textureFormatSet: 0
-  platformSettings:
-  - buildTarget: DefaultTexturePlatform
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 0
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
-  - buildTarget: Standalone
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 0
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
+  buildTargetSettings: []
   spriteSheet:
-    serializedVersion: 2
     sprites: []
     outline: []
-    physicsShape: []
   spritePackingTag: 
   userData: 
   assetBundleName: 

--- a/Internal/Shaders/BrushPreview.shader
+++ b/Internal/Shaders/BrushPreview.shader
@@ -1,32 +1,35 @@
 ﻿// Based on "Legacy Shaders/Transparent/Diffuse"
 Shader "SabreCSG/BrushPreview"
 {
-Properties {
-	_Color ("Main Color", Color) = (1,1,1,1)
-}
+	Properties
+	{
+		_Color ("Main Color", Color) = (1,1,1,1)
+	}
 
-SubShader {
-	Fog { Mode Off }
-	Tags {"Queue"="Transparent" "IgnoreProjector"="True" "RenderType"="Transparent"}
-	LOD 200
+	SubShader
+	{
+		Fog { Mode Off }
+		Tags {"Queue"="Transparent" "IgnoreProjector"="True" "RenderType"="Transparent"}
+		LOD 200
 
-CGPROGRAM
-#pragma surface surf Lambert alpha:blend nofog
+		CGPROGRAM
+			#pragma surface surf Lambert alpha:blend nofog
 
-fixed4 _Color;
+			fixed4 _Color;
 
-struct Input {
-	fixed4 color; // Can't declare empty structs in CG, so just put a filler variable to get it compiling
-};
+			struct Input
+			{
+				fixed4 color; // Can't declare empty structs in CG, so just put a filler variable to get it compiling
+			};
 
-void surf (Input IN, inout SurfaceOutput o) {
-	fixed4 c = _Color;
-	
-	o.Albedo = c.rgb;
-	o.Alpha = c.a;
-}
-ENDCG
-}
+			void surf (Input IN, inout SurfaceOutput o)
+			{
+				fixed4 c = _Color;
+				o.Albedo = c.rgb;
+				o.Alpha = c.a;
+			}
+		ENDCG
+	}
 
-Fallback "Legacy Shaders/Transparent/VertexLit"
+	Fallback "Legacy Shaders/Transparent/VertexLit"
 }

--- a/Internal/Shaders/Grayscale-GUITexture.shader
+++ b/Internal/Shaders/Grayscale-GUITexture.shader
@@ -1,60 +1,63 @@
-
-Shader "Hidden/Grayscale-GUITexture" 
+Shader "Hidden/Grayscale-GUITexture"
 {
-	Properties { _MainTex ("Texture", any) = "" {} } 
-
-	SubShader {
-
-		Tags { "ForceSupported" = "True" "RenderType"="Overlay" } 
-		
-		Lighting Off 
-		Blend SrcAlpha OneMinusSrcAlpha 
-		Cull Off 
-		ZWrite Off 
-		ZTest Always 
-		
-		Pass {	
-			CGPROGRAM
-			#pragma vertex vert
-			#pragma fragment frag
-
-			#include "UnityCG.cginc"
-
-			struct appdata_t {
-				float4 vertex : POSITION;
-				fixed4 color : COLOR;
-				float2 texcoord : TEXCOORD0;
-			};
-
-			struct v2f {
-				float4 vertex : SV_POSITION;
-				fixed4 color : COLOR;
-				float2 texcoord : TEXCOORD0;
-			};
-
-			sampler2D _MainTex;
-
-			uniform float4 _MainTex_ST;
-			
-			v2f vert (appdata_t v)
-			{
-				v2f o;
-				o.vertex = mul(UNITY_MATRIX_MVP, v.vertex);
-				o.color = v.color;
-				o.texcoord = TRANSFORM_TEX(v.texcoord,_MainTex);
-				return o;
-			}
-
-			fixed4 frag (v2f i) : SV_Target
-			{
-				fixed4 col = tex2D(_MainTex, i.texcoord);
-				col.rgb = dot(float3(0.222, 0.707, 0.071), col.rgb);
-				
-				return 2.0f * col * i.color;
-			}
-			ENDCG 
-		}
+	Properties
+	{
+		_MainTex ("Texture", any) = "" {}
 	} 
+
+	SubShader
+	{
+		Tags { "ForceSupported" = "True" "RenderType"="Overlay" }
+		Lighting Off
+		Blend SrcAlpha OneMinusSrcAlpha
+		Cull Off
+		ZWrite Off
+		ZTest Always
+		
+		Pass
+		{
+			CGPROGRAM
+				#pragma vertex vert
+				#pragma fragment frag
+
+				#include "UnityCG.cginc"
+
+				struct appdata_t
+				{
+					float4 vertex : POSITION;
+					fixed4 color : COLOR;
+					float2 texcoord : TEXCOORD0;
+				};
+
+				struct v2f
+				{
+					float4 vertex : SV_POSITION;
+					fixed4 color : COLOR;
+					float2 texcoord : TEXCOORD0;
+				};
+
+				sampler2D _MainTex;
+
+				uniform float4 _MainTex_ST;
+			
+				v2f vert (appdata_t v)
+				{
+					v2f o;
+					o.vertex = UnityObjectToClipPos(v.vertex);
+					o.color = v.color;
+					o.texcoord = TRANSFORM_TEX(v.texcoord,_MainTex);
+					return o;
+				}
+
+				fixed4 frag (v2f i) : SV_Target
+				{
+					fixed4 col = tex2D(_MainTex, i.texcoord);
+					col.rgb = dot(float3(0.222, 0.707, 0.071), col.rgb);
+					return 2.0f * col * i.color;
+				}
+			ENDCG
+		}
+	}
 	
-	Fallback off 
+	Fallback off
 }

--- a/Internal/Shaders/Grayscale-GUITexture.shader
+++ b/Internal/Shaders/Grayscale-GUITexture.shader
@@ -43,7 +43,7 @@ Shader "Hidden/Grayscale-GUITexture"
 				v2f vert (appdata_t v)
 				{
 					v2f o;
-					o.vertex = UnityObjectToClipPos(v.vertex);
+					o.vertex = mul(UNITY_MATRIX_MVP, v.vertex);
 					o.color = v.color;
 					o.texcoord = TRANSFORM_TEX(v.texcoord,_MainTex);
 					return o;

--- a/Scripts/Brushes/CompoundBrushes/Editor/ShapeEditorWindow.cs
+++ b/Scripts/Brushes/CompoundBrushes/Editor/ShapeEditorWindow.cs
@@ -970,7 +970,7 @@ namespace Sabresaurus.SabreCSG.ShapeEditor
 #if UNITY_5_4_OR_NEWER
             viewportScroll = new Vector2(Screen.safeArea.width / 2.0f / EditorGUIUtility.pixelsPerPoint, Screen.safeArea.height / 2.0f / EditorGUIUtility.pixelsPerPoint);
 #else
-            viewportScroll = new Vector2(Screen.safeArea.width / 2.0f, Screen.safeArea.height / 2.0f);
+            viewportScroll = new Vector2(Screen.width / 2.0f, Screen.height / 2.0f);
 #endif
         }
 
@@ -1327,7 +1327,11 @@ namespace Sabresaurus.SabreCSG.ShapeEditor
 
         private Rect GetViewportRect()
         {
+#if UNITY_5_4_OR_NEWER
             Rect viewportRect = Screen.safeArea;
+#else
+            Rect viewportRect = new Rect(0, 0, Screen.width, Screen.height);
+#endif
             viewportRect.y += 18;
             viewportRect.height -= 40;
             return viewportRect;
@@ -1456,7 +1460,7 @@ namespace Sabresaurus.SabreCSG.ShapeEditor
 #if UNITY_5_4_OR_NEWER
             PopupWindow.Show(new Rect((Screen.safeArea.width / 2.0f / EditorGUIUtility.pixelsPerPoint) - (size.x / 2.0f), (Screen.safeArea.height / 2.0f / EditorGUIUtility.pixelsPerPoint) - (size.y / 2.0f), 0, 0), popup);
 #else
-            PopupWindow.Show(new Rect((Screen.safeArea.width / 2.0f) - (size.x / 2.0f), (Screen.safeArea.height / 2.0f) - (size.y / 2.0f), 0, 0), popup);
+            PopupWindow.Show(new Rect((Screen.width / 2.0f) - (size.x / 2.0f), (Screen.height / 2.0f) - (size.y / 2.0f), 0, 0), popup);
 #endif
         }
 

--- a/Scripts/Compatibility.meta
+++ b/Scripts/Compatibility.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 2c869506319936e48871703f87ed0f83
+folderAsset: yes
+timeCreated: 1521408336
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Compatibility/Vector2Int.cs
+++ b/Scripts/Compatibility/Vector2Int.cs
@@ -1,0 +1,260 @@
+﻿#if (UNITY_EDITOR || RUNTIME_CSG) && !UNITY_2017_2_OR_NEWER
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using UnityEngine;
+
+namespace UnityEngine
+{
+    /// <summary>
+    /// A complete reimplementation of Vector2Int for older Unity versions.
+    /// </summary>
+    [System.Serializable]
+    public struct Vector2Int
+    {
+        [SerializeField]
+        public int x;
+
+        [SerializeField]
+        public int y;
+
+        private static readonly Vector2Int s_Zero = new Vector2Int(0, 0);
+
+        private static readonly Vector2Int s_One = new Vector2Int(1, 1);
+
+        private static readonly Vector2Int s_Up = new Vector2Int(0, 1);
+
+        private static readonly Vector2Int s_Down = new Vector2Int(0, -1);
+
+        private static readonly Vector2Int s_Left = new Vector2Int(-1, 0);
+
+        private static readonly Vector2Int s_Right = new Vector2Int(1, 0);
+
+        public int this[int index]
+        {
+            get
+            {
+                int result;
+                if (index != 0)
+                {
+                    if (index != 1)
+                    {
+                        throw new IndexOutOfRangeException(string.Format("Invalid Vector2Int index addressed: {0}!", index));
+                    }
+                    result = this.y;
+                }
+                else
+                {
+                    result = this.x;
+                }
+                return result;
+            }
+            set
+            {
+                if (index != 0)
+                {
+                    if (index != 1)
+                    {
+                        throw new IndexOutOfRangeException(string.Format("Invalid Vector2Int index addressed: {0}!", index));
+                    }
+                    this.y = value;
+                }
+                else
+                {
+                    this.x = value;
+                }
+            }
+        }
+
+        public float magnitude
+        {
+            get
+            {
+                return Mathf.Sqrt((float)(this.x * this.x + this.y * this.y));
+            }
+        }
+
+        public int sqrMagnitude
+        {
+            get
+            {
+                return this.x * this.x + this.y * this.y;
+            }
+        }
+
+        public static Vector2Int zero
+        {
+            get
+            {
+                return Vector2Int.s_Zero;
+            }
+        }
+
+        public static Vector2Int one
+        {
+            get
+            {
+                return Vector2Int.s_One;
+            }
+        }
+
+        public static Vector2Int up
+        {
+            get
+            {
+                return Vector2Int.s_Up;
+            }
+        }
+
+        public static Vector2Int down
+        {
+            get
+            {
+                return Vector2Int.s_Down;
+            }
+        }
+
+        public static Vector2Int left
+        {
+            get
+            {
+                return Vector2Int.s_Left;
+            }
+        }
+
+        public static Vector2Int right
+        {
+            get
+            {
+                return Vector2Int.s_Right;
+            }
+        }
+
+        public Vector2Int(int x, int y)
+        {
+            this.x = x;
+            this.y = y;
+        }
+
+        public void Set(int x, int y)
+        {
+            this.x = x;
+            this.y = y;
+        }
+
+        public static float Distance(Vector2Int a, Vector2Int b)
+        {
+            return (a - b).magnitude;
+        }
+
+        public static Vector2Int Min(Vector2Int lhs, Vector2Int rhs)
+        {
+            return new Vector2Int(Mathf.Min(lhs.x, rhs.x), Mathf.Min(lhs.y, rhs.y));
+        }
+
+        public static Vector2Int Max(Vector2Int lhs, Vector2Int rhs)
+        {
+            return new Vector2Int(Mathf.Max(lhs.x, rhs.x), Mathf.Max(lhs.y, rhs.y));
+        }
+
+        public static Vector2Int Scale(Vector2Int a, Vector2Int b)
+        {
+            return new Vector2Int(a.x * b.x, a.y * b.y);
+        }
+
+        public void Scale(Vector2Int scale)
+        {
+            this.x *= scale.x;
+            this.y *= scale.y;
+        }
+
+        public void Clamp(Vector2Int min, Vector2Int max)
+        {
+            this.x = Math.Max(min.x, this.x);
+            this.x = Math.Min(max.x, this.x);
+            this.y = Math.Max(min.y, this.y);
+            this.y = Math.Min(max.y, this.y);
+        }
+
+        public static implicit operator Vector2(Vector2Int v)
+        {
+            return new Vector2((float)v.x, (float)v.y);
+        }
+
+        public static Vector2Int FloorToInt(Vector2 v)
+        {
+            return new Vector2Int(Mathf.FloorToInt(v.x), Mathf.FloorToInt(v.y));
+        }
+
+        public static Vector2Int CeilToInt(Vector2 v)
+        {
+            return new Vector2Int(Mathf.CeilToInt(v.x), Mathf.CeilToInt(v.y));
+        }
+
+        public static Vector2Int RoundToInt(Vector2 v)
+        {
+            return new Vector2Int(Mathf.RoundToInt(v.x), Mathf.RoundToInt(v.y));
+        }
+
+        public static Vector2Int operator +(Vector2Int a, Vector2Int b)
+        {
+            return new Vector2Int(a.x + b.x, a.y + b.y);
+        }
+
+        public static Vector2Int operator -(Vector2Int a, Vector2Int b)
+        {
+            return new Vector2Int(a.x - b.x, a.y - b.y);
+        }
+
+        public static Vector2Int operator *(Vector2Int a, Vector2Int b)
+        {
+            return new Vector2Int(a.x * b.x, a.y * b.y);
+        }
+
+        public static Vector2Int operator *(Vector2Int a, int b)
+        {
+            return new Vector2Int(a.x * b, a.y * b);
+        }
+
+        public static bool operator ==(Vector2Int lhs, Vector2Int rhs)
+        {
+            return lhs.x == rhs.x && lhs.y == rhs.y;
+        }
+
+        public static bool operator !=(Vector2Int lhs, Vector2Int rhs)
+        {
+            return !(lhs == rhs);
+        }
+
+        public override bool Equals(object other)
+        {
+            bool result;
+            if (!(other is Vector2Int))
+            {
+                result = false;
+            }
+            else
+            {
+                Vector2Int vector2Int = (Vector2Int)other;
+                result = (this.x.Equals(vector2Int.x) && this.y.Equals(vector2Int.y));
+            }
+            return result;
+        }
+
+        public override int GetHashCode()
+        {
+            return this.x.GetHashCode() ^ this.y.GetHashCode() << 2;
+        }
+
+        public override string ToString()
+        {
+            return String.Format("({0}, {1})", new object[]
+            {
+                this.x,
+                this.y
+            });
+        }
+    }
+}
+#endif

--- a/Scripts/Compatibility/Vector2Int.cs.meta
+++ b/Scripts/Compatibility/Vector2Int.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: fce035588f48edc48b5dcca89ead0105
+timeCreated: 1521408337
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Shaders/Diffuse-VertexColored.shader
+++ b/Shaders/Diffuse-VertexColored.shader
@@ -1,50 +1,54 @@
-﻿Shader "SabreCSG/Diffuse (vertex colored) " {
-Properties {
-}
-SubShader {
-	Tags { "RenderType"="Opaque" }
-	LOD 200
-
-Pass {
-CGPROGRAM
-#pragma vertex vert
-#pragma fragment frag
-#include "UnityShaderVariables.cginc"
-
-	// vertex shader input data
-	struct appdata 
+﻿Shader "SabreCSG/Diffuse (vertex colored) "
+{
+	Properties
 	{
-		float3 pos : POSITION;
-		half4 color : COLOR;
-	};
-
-	// vertex-to-fragment interpolators
-	struct v2f 
-	{
-		fixed4 color : COLOR0;
-		float4 pos : SV_POSITION;
-	};
-
-	// vertex shader
-	v2f vert(appdata IN) 
-	{
-		v2f o;
-		half4 color = IN.color;
-		o.color = color;
-		// transform position
-		o.pos = mul(UNITY_MATRIX_MVP, float4(IN.pos,1));
-		return o;
 	}
-
-	// fragment shader
-	fixed4 frag(v2f IN) : SV_Target
+	SubShader
 	{
-		fixed4 col;
-		col = IN.color;
-		return col;
+		Tags { "RenderType"="Opaque" }
+		LOD 200
+
+		Pass
+		{
+			CGPROGRAM
+				#pragma vertex vert
+				#pragma fragment frag
+				#include "UnityShaderVariables.cginc"
+
+				// vertex shader input data
+				struct appdata 
+				{
+					float3 pos : POSITION;
+					half4 color : COLOR;
+				};
+
+				// vertex-to-fragment interpolators
+				struct v2f 
+				{
+					fixed4 color : COLOR0;
+					float4 pos : SV_POSITION;
+				};
+
+				// vertex shader
+				v2f vert(appdata IN) 
+				{
+					v2f o;
+					half4 color = IN.color;
+					o.color = color;
+					// transform position
+					o.pos = UnityObjectToClipPos(float4(IN.pos,1));
+					return o;
+				}
+
+				// fragment shader
+				fixed4 frag(v2f IN) : SV_Target
+				{
+					fixed4 col;
+					col = IN.color;
+					return col;
+				}
+			ENDCG
+		}
 	}
-ENDCG
-}
-}
-Fallback "VertexLit"
+	Fallback "VertexLit"
 }

--- a/Shaders/Diffuse-VertexColored.shader
+++ b/Shaders/Diffuse-VertexColored.shader
@@ -36,7 +36,7 @@
 					half4 color = IN.color;
 					o.color = color;
 					// transform position
-					o.pos = UnityObjectToClipPos(float4(IN.pos,1));
+					o.pos = mul(UNITY_MATRIX_MVP, float4(IN.pos,1));
 					return o;
 				}
 

--- a/Shaders/Diffuse-VertexColoredLit.shader
+++ b/Shaders/Diffuse-VertexColoredLit.shader
@@ -1,39 +1,44 @@
-﻿Shader "SabreCSG/Diffuse (vertex colored, lit) " {
-	Properties {
+﻿Shader "SabreCSG/Diffuse (vertex colored, lit) "
+{
+	Properties
+	{
 		_MainTex ("Albedo (RGB)", 2D) = "white" {}
 		_Glossiness ("Smoothness", Range(0,1)) = 0.5
 		_Metallic ("Metallic", Range(0,1)) = 0.0
 	}
-	SubShader {
+	SubShader
+	{
 		Tags { "RenderType"="Opaque" }
 		LOD 200
 		
 		CGPROGRAM
-		// Physically based Standard lighting model, and enable shadows on all light types
-		#pragma surface surf Standard fullforwardshadows
+			// Physically based Standard lighting model, and enable shadows on all light types
+			#pragma surface surf Standard fullforwardshadows
 
-		// Use shader model 3.0 target, to get nicer looking lighting
-		#pragma target 3.0
+			// Use shader model 3.0 target, to get nicer looking lighting
+			#pragma target 3.0
 
-		sampler2D _MainTex;
+			sampler2D _MainTex;
 
-		struct Input {
-			float2 uv_MainTex;
-			fixed4 color : COLOR;
-		};
+			struct Input
+			{
+				float2 uv_MainTex;
+				fixed4 color : COLOR;
+			};
 
-		half _Glossiness;
-		half _Metallic;
+			half _Glossiness;
+			half _Metallic;
 
-		void surf (Input IN, inout SurfaceOutputStandard o) {
-			// Albedo comes from a texture tinted by color
-			fixed4 c = tex2D (_MainTex, IN.uv_MainTex);
-			o.Albedo = IN.color;
-			// Metallic and smoothness come from slider variables
-			o.Metallic = _Metallic;
-			o.Smoothness = _Glossiness;
-			o.Alpha = c.a;
-		}
+			void surf (Input IN, inout SurfaceOutputStandard o)
+			{
+				// Albedo comes from a texture tinted by color
+				fixed4 c = tex2D (_MainTex, IN.uv_MainTex);
+				o.Albedo = IN.color;
+				// Metallic and smoothness come from slider variables
+				o.Metallic = _Metallic;
+				o.Smoothness = _Glossiness;
+				o.Alpha = c.a;
+			}
 		ENDCG
 	}
 	FallBack "Diffuse"

--- a/Shaders/Handle.shader
+++ b/Shaders/Handle.shader
@@ -1,63 +1,68 @@
-﻿Shader "SabreCSG/Handle" {
-Properties{
+﻿Shader "SabreCSG/Handle"
+{
+	Properties
+	{
 		_MainTex("Base (RGB)", 2D) = "white" { }
 	}
-	SubShader{
-		Pass{
-		ZTest Always
-		ZWrite Off
-		Cull Off
-		Blend SrcAlpha OneMinusSrcAlpha
-		CGPROGRAM
-#pragma vertex vert
-#pragma fragment frag
-#include "UnityShaderVariables.cginc"
-
-		// uniforms
-		float4 _MainTex_ST;
-
-		// vertex shader input data
-	struct appdata {
-		float3 pos : POSITION;
-		half4 color : COLOR;
-		float3 uv0 : TEXCOORD0;
-	};
-
-	// vertex-to-fragment interpolators
-	struct v2f {
-		fixed4 color : COLOR0;
-		float2 uv0 : TEXCOORD0;
-		float4 pos : SV_POSITION;
-	};
-
-	// vertex shader
-	v2f vert(appdata IN) {
-		v2f o;
-		half4 color = IN.color;
-		half3 viewDir = 0.0;
-		o.color = saturate(color);
-		// compute texture coordinates
-		o.uv0 = IN.uv0.xy * _MainTex_ST.xy + _MainTex_ST.zw;
-		// transform position
-		o.pos = mul(UNITY_MATRIX_MVP, float4(IN.pos,1));
-		return o;
-	}
-
-	// textures
-	sampler2D _MainTex;
-
-
-	fixed4 frag(v2f IN) : SV_Target
+	SubShader
 	{
-		fixed4 col;
-		fixed4 tex, tmp0, tmp1, tmp2;
-		// SetTexture #0
-		tex = tex2D(_MainTex, IN.uv0.xy);
-		col = IN.color * tex;
-//		col.a = 1;
-		return col;
-	}
-		ENDCG
-	}
+		Pass
+		{
+			ZTest Always
+			ZWrite Off
+			Cull Off
+			Blend SrcAlpha OneMinusSrcAlpha
+			CGPROGRAM
+				#pragma vertex vert
+				#pragma fragment frag
+				#include "UnityShaderVariables.cginc"
+
+				// uniforms
+				float4 _MainTex_ST;
+
+				// vertex shader input data
+				struct appdata
+				{
+					float3 pos : POSITION;
+					half4 color : COLOR;
+					float3 uv0 : TEXCOORD0;
+				};
+
+				// vertex-to-fragment interpolators
+				struct v2f
+				{
+					fixed4 color : COLOR0;
+					float2 uv0 : TEXCOORD0;
+					float4 pos : SV_POSITION;
+				};
+
+				// vertex shader
+				v2f vert(appdata IN)
+				{
+					v2f o;
+					half4 color = IN.color;
+					half3 viewDir = 0.0;
+					o.color = saturate(color);
+					// compute texture coordinates
+					o.uv0 = IN.uv0.xy * _MainTex_ST.xy + _MainTex_ST.zw;
+					// transform position
+					o.pos = UnityObjectToClipPos(float4(IN.pos,1));
+					return o;
+				}
+
+				// textures
+				sampler2D _MainTex;
+
+				fixed4 frag(v2f IN) : SV_Target
+				{
+					fixed4 col;
+					fixed4 tex, tmp0, tmp1, tmp2;
+					// SetTexture #0
+					tex = tex2D(_MainTex, IN.uv0.xy);
+					col = IN.color * tex;
+					return col;
+				}
+			ENDCG
+		}
 	}
 }

--- a/Shaders/Handle.shader
+++ b/Shaders/Handle.shader
@@ -46,7 +46,7 @@
 					// compute texture coordinates
 					o.uv0 = IN.uv0.xy * _MainTex_ST.xy + _MainTex_ST.zw;
 					// transform position
-					o.pos = UnityObjectToClipPos(float4(IN.pos,1));
+					o.pos = mul(UNITY_MATRIX_MVP, float4(IN.pos,1));
 					return o;
 				}
 

--- a/Shaders/Line.shader
+++ b/Shaders/Line.shader
@@ -37,7 +37,7 @@
 					o.color = saturate(color);
 					// compute texture coordinates
 					// transform position
-					o.pos = UnityObjectToClipPos(float4(IN.pos,1));
+					o.pos = mul(UNITY_MATRIX_MVP, float4(IN.pos,1));
 					return o;
 				}
 

--- a/Shaders/Line.shader
+++ b/Shaders/Line.shader
@@ -1,47 +1,54 @@
-﻿Shader "SabreCSG/Line" {
-	SubShader{
-		Pass{
-		ZWrite Off
-		Cull Off
-		Blend SrcAlpha OneMinusSrcAlpha
-		CGPROGRAM
-#pragma vertex vert
-#pragma fragment frag
-#include "UnityShaderVariables.cginc"
+﻿Shader "SabreCSG/Line"
+{
+	SubShader
+	{
+		Pass
+		{
+			ZWrite Off
+			Cull Off
+			Blend SrcAlpha OneMinusSrcAlpha
+			CGPROGRAM
+				#pragma vertex vert
+				#pragma fragment frag
+				#include "UnityShaderVariables.cginc"
 
-		// uniforms
+				// uniforms
 
-		// vertex shader input data
-	struct appdata {
-		float3 pos : POSITION;
-		half4 color : COLOR;
-	};
+				// vertex shader input data
+				struct appdata
+				{
+					float3 pos : POSITION;
+					half4 color : COLOR;
+				};
 
-	// vertex-to-fragment interpolators
-	struct v2f {
-		fixed4 color : COLOR0;
-		float4 pos : SV_POSITION;
-	};
+				// vertex-to-fragment interpolators
+				struct v2f
+				{
+					fixed4 color : COLOR0;
+					float4 pos : SV_POSITION;
+				};
 
-	// vertex shader
-	v2f vert(appdata IN) {
-		v2f o;
-		half4 color = IN.color;
-		half3 viewDir = 0.0;
-		o.color = saturate(color);
-		// compute texture coordinates
-		// transform position
-		o.pos = mul(UNITY_MATRIX_MVP, float4(IN.pos,1));
-		return o;
-	}
+				// vertex shader
+				v2f vert(appdata IN)
+				{
+					v2f o;
+					half4 color = IN.color;
+					half3 viewDir = 0.0;
+					o.color = saturate(color);
+					// compute texture coordinates
+					// transform position
+					o.pos = UnityObjectToClipPos(float4(IN.pos,1));
+					return o;
+				}
 
-	// fragment shader
-	fixed4 frag(v2f IN) : SV_Target{
-		fixed4 col;
-	col = IN.color;
-	return col;
-	}
-		ENDCG
-	}
+				// fragment shader
+				fixed4 frag(v2f IN) : SV_Target
+				{
+					fixed4 col;
+					col = IN.color;
+					return col;
+				}
+			ENDCG
+		}
 	}
 }

--- a/Shaders/LineDashed.shader
+++ b/Shaders/LineDashed.shader
@@ -1,57 +1,63 @@
-﻿Shader "SabreCSG/Line Dashed" {
-	SubShader{
-		Pass{
-		ZWrite Off
-		Cull Off
-		Blend SrcAlpha OneMinusSrcAlpha
-		CGPROGRAM
-#pragma vertex vert
-#pragma fragment frag
-#include "UnityShaderVariables.cginc"
-
-		// uniforms
-
-		// vertex shader input data
-	struct appdata {
-		float3 pos : POSITION;
-		float2 uv : TEXCOORD0;
-		half4 color : COLOR;
-	};
-
-	// vertex-to-fragment interpolators
-	struct v2f {
-		fixed4 color : COLOR0;
-		float2 uv : TEXCOORD0;
-		float4 pos : SV_POSITION;
-	};
-
-	// vertex shader
-	v2f vert(appdata IN) {
-		v2f o;
-		half4 color = IN.color;
-		half3 viewDir = 0.0;
-		o.color = saturate(color);
-		// compute texture coordinates
-		// transform position
-		o.pos = mul(UNITY_MATRIX_MVP, float4(IN.pos,1));
-		o.uv = IN.uv;
-		return o;
-	}
-
-	// fragment shader
-	fixed4 frag(v2f IN) : SV_Target
+﻿Shader "SabreCSG/Line Dashed"
+{
+	SubShader
 	{
-		fixed4 col;
-		col = IN.color;
-		// This should flip between 0 and 1 values 4 times a UV unit
-		float interpolant = floor(2 * frac((IN.uv.x) * 2));
+		Pass
+		{
+			ZWrite Off
+			Cull Off
+			Blend SrcAlpha OneMinusSrcAlpha
+			CGPROGRAM
+				#pragma vertex vert
+				#pragma fragment frag
+				#include "UnityShaderVariables.cginc"
 
-		// Set the target color as the supplied color or black based on the interpolant
-		col = lerp(col, fixed4(0,0,0,1), interpolant);
+				// uniforms
 
-		return col;
-	}
-		ENDCG
-	}
+				// vertex shader input data
+				struct appdata
+				{
+					float3 pos : POSITION;
+					float2 uv : TEXCOORD0;
+					half4 color : COLOR;
+				};
+
+				// vertex-to-fragment interpolators
+				struct v2f
+				{
+					fixed4 color : COLOR0;
+					float2 uv : TEXCOORD0;
+					float4 pos : SV_POSITION;
+				};
+
+				// vertex shader
+				v2f vert(appdata IN)
+				{
+					v2f o;
+					half4 color = IN.color;
+					half3 viewDir = 0.0;
+					o.color = saturate(color);
+					// compute texture coordinates
+					// transform position
+					o.pos = UnityObjectToClipPos(float4(IN.pos,1));
+					o.uv = IN.uv;
+					return o;
+				}
+
+				// fragment shader
+				fixed4 frag(v2f IN) : SV_Target
+				{
+					fixed4 col;
+					col = IN.color;
+					// This should flip between 0 and 1 values 4 times a UV unit
+					float interpolant = floor(2 * frac((IN.uv.x) * 2));
+
+					// Set the target color as the supplied color or black based on the interpolant
+					col = lerp(col, fixed4(0,0,0,1), interpolant);
+
+					return col;
+				}
+			ENDCG
+		}
 	}
 }

--- a/Shaders/LineDashed.shader
+++ b/Shaders/LineDashed.shader
@@ -39,7 +39,7 @@
 					o.color = saturate(color);
 					// compute texture coordinates
 					// transform position
-					o.pos = UnityObjectToClipPos(float4(IN.pos,1));
+					o.pos = mul(UNITY_MATRIX_MVP, float4(IN.pos,1));
 					o.uv = IN.uv;
 					return o;
 				}

--- a/Shaders/LineDashedAlpha.shader
+++ b/Shaders/LineDashedAlpha.shader
@@ -1,57 +1,63 @@
-﻿Shader "SabreCSG/Line Dashed Alpha" {
-	SubShader{
-		Pass{
-		ZWrite Off
-		Cull Off
-		Blend SrcAlpha OneMinusSrcAlpha
-		CGPROGRAM
-#pragma vertex vert
-#pragma fragment frag
-#include "UnityShaderVariables.cginc"
-
-		// uniforms
-
-		// vertex shader input data
-	struct appdata {
-		float3 pos : POSITION;
-		float2 uv : TEXCOORD0;
-		half4 color : COLOR;
-	};
-
-	// vertex-to-fragment interpolators
-	struct v2f {
-		fixed4 color : COLOR0;
-		float2 uv : TEXCOORD0;
-		float4 pos : SV_POSITION;
-	};
-
-	// vertex shader
-	v2f vert(appdata IN) {
-		v2f o;
-		half4 color = IN.color;
-		half3 viewDir = 0.0;
-		o.color = saturate(color);
-		// compute texture coordinates
-		// transform position
-		o.pos = mul(UNITY_MATRIX_MVP, float4(IN.pos,1));
-		o.uv = IN.uv;
-		return o;
-	}
-
-	// fragment shader
-	fixed4 frag(v2f IN) : SV_Target
+﻿Shader "SabreCSG/Line Dashed Alpha"
+{
+	SubShader
 	{
-		fixed4 col;
-		col = IN.color;
-		// This should flip between 0 and 1 values 4 times a UV unit
-		float interpolant = floor(2 * frac((IN.uv.x) * 2));
+		Pass
+		{
+			ZWrite Off
+			Cull Off
+			Blend SrcAlpha OneMinusSrcAlpha
+			CGPROGRAM
+				#pragma vertex vert
+				#pragma fragment frag
+				#include "UnityShaderVariables.cginc"
 
-		// Set the target color as the supplied color or black based on the interpolant
-		col.a *= interpolant;
+				// uniforms
 
-		return col;
-	}
-		ENDCG
-	}
+				// vertex shader input data
+				struct appdata
+				{
+					float3 pos : POSITION;
+					float2 uv : TEXCOORD0;
+					half4 color : COLOR;
+				};
+
+				// vertex-to-fragment interpolators
+				struct v2f
+				{
+					fixed4 color : COLOR0;
+					float2 uv : TEXCOORD0;
+					float4 pos : SV_POSITION;
+				};
+
+				// vertex shader
+				v2f vert(appdata IN)
+				{
+					v2f o;
+					half4 color = IN.color;
+					half3 viewDir = 0.0;
+					o.color = saturate(color);
+					// compute texture coordinates
+					// transform position
+					o.pos = UnityObjectToClipPos(float4(IN.pos,1));
+					o.uv = IN.uv;
+					return o;
+				}
+
+				// fragment shader
+				fixed4 frag(v2f IN) : SV_Target
+				{
+					fixed4 col;
+					col = IN.color;
+					// This should flip between 0 and 1 values 4 times a UV unit
+					float interpolant = floor(2 * frac((IN.uv.x) * 2));
+
+					// Set the target color as the supplied color or black based on the interpolant
+					col.a *= interpolant;
+
+					return col;
+				}
+			ENDCG
+		}
 	}
 }

--- a/Shaders/LineDashedAlpha.shader
+++ b/Shaders/LineDashedAlpha.shader
@@ -39,7 +39,7 @@
 					o.color = saturate(color);
 					// compute texture coordinates
 					// transform position
-					o.pos = UnityObjectToClipPos(float4(IN.pos,1));
+					o.pos = mul(UNITY_MATRIX_MVP, float4(IN.pos,1));
 					o.uv = IN.uv;
 					return o;
 				}

--- a/Shaders/Plane.shader
+++ b/Shaders/Plane.shader
@@ -44,7 +44,7 @@
 					// compute texture coordinates
 					o.uv0 = IN.uv0.xy * _MainTex_ST.xy + _MainTex_ST.zw;
 					// transform position
-					o.pos = UnityObjectToClipPos(float4(IN.pos,1));
+					o.pos = mul(UNITY_MATRIX_MVP, float4(IN.pos,1));
 					return o;
 				}
 

--- a/Shaders/Plane.shader
+++ b/Shaders/Plane.shader
@@ -1,62 +1,70 @@
-﻿Shader "SabreCSG/Plane" {
-	Properties{
+﻿Shader "SabreCSG/Plane"
+{
+	Properties
+	{
 		_MainTex("Base (RGB)", 2D) = "white" { }
 	}
-		SubShader{
-		Pass{
-		ZWrite Off
-		Blend SrcAlpha OneMinusSrcAlpha
-		CGPROGRAM
-#pragma vertex vert
-#pragma fragment frag
-#include "UnityShaderVariables.cginc"
+	SubShader
+	{
+		Pass
+		{
+			ZWrite Off
+			Blend SrcAlpha OneMinusSrcAlpha
+			CGPROGRAM
+				#pragma vertex vert
+				#pragma fragment frag
+				#include "UnityShaderVariables.cginc"
 
-		// uniforms
-		float4 _MainTex_ST;
+				// uniforms
+				float4 _MainTex_ST;
 
-	// vertex shader input data
-	struct appdata {
-		float3 pos : POSITION;
-		half4 color : COLOR;
-		float3 uv0 : TEXCOORD0;
-	};
+				// vertex shader input data
+				struct appdata
+				{
+					float3 pos : POSITION;
+					half4 color : COLOR;
+					float3 uv0 : TEXCOORD0;
+				};
 
-	// vertex-to-fragment interpolators
-	struct v2f {
-		fixed4 color : COLOR0;
-		float2 uv0 : TEXCOORD0;
-		float4 pos : SV_POSITION;
-	};
+				// vertex-to-fragment interpolators
+				struct v2f
+				{
+					fixed4 color : COLOR0;
+					float2 uv0 : TEXCOORD0;
+					float4 pos : SV_POSITION;
+				};
 
-	// vertex shader
-	v2f vert(appdata IN) {
-		v2f o;
-		half4 color = IN.color;
-		half3 viewDir = 0.0;
-		o.color = saturate(color);
-		// compute texture coordinates
-		o.uv0 = IN.uv0.xy * _MainTex_ST.xy + _MainTex_ST.zw;
-		// transform position
-		o.pos = mul(UNITY_MATRIX_MVP, float4(IN.pos,1));
-		return o;
-	}
+				// vertex shader
+				v2f vert(appdata IN)
+				{
+					v2f o;
+					half4 color = IN.color;
+					half3 viewDir = 0.0;
+					o.color = saturate(color);
+					// compute texture coordinates
+					o.uv0 = IN.uv0.xy * _MainTex_ST.xy + _MainTex_ST.zw;
+					// transform position
+					o.pos = UnityObjectToClipPos(float4(IN.pos,1));
+					return o;
+				}
 
-	// textures
-	sampler2D _MainTex;
+				// textures
+				sampler2D _MainTex;
 
-	// fragment shader
-	fixed4 frag(v2f IN) : SV_Target{
-		fixed4 col;
-	fixed4 tex, tmp0, tmp1, tmp2;
-	// SetTexture #0
-	tex = tex2D(_MainTex, IN.uv0.xy);
-	col = IN.color * tex;
-	return col;
-	}
+				// fragment shader
+				fixed4 frag(v2f IN) : SV_Target
+				{
+					fixed4 col;
+					fixed4 tex, tmp0, tmp1, tmp2;
+					// SetTexture #0
+					tex = tex2D(_MainTex, IN.uv0.xy);
+					col = IN.color * tex;
+					return col;
+				}
 
-		// texenvs
-		//! TexEnv0: 01000101 01000101 [_MainTex]
-		ENDCG
-	}
+				// texenvs
+				//! TexEnv0: 01000101 01000101 [_MainTex]
+			ENDCG
+		}
 	}
 }

--- a/Shaders/Preview.shader
+++ b/Shaders/Preview.shader
@@ -46,7 +46,7 @@
 					// compute texture coordinates
 					o.uv0 = IN.uv0.xy * _MainTex_ST.xy + _MainTex_ST.zw;
 					// transform position
-					o.pos = UnityObjectToClipPos(float4(IN.pos,1));
+					o.pos = mul(UNITY_MATRIX_MVP, float4(IN.pos,1));
 					return o;
 				}
 

--- a/Shaders/Preview.shader
+++ b/Shaders/Preview.shader
@@ -1,74 +1,77 @@
-﻿Shader "SabreCSG/Preview" {
-Properties{
+﻿Shader "SabreCSG/Preview"
+{
+	Properties
+	{
 		_MainTex("Base (RGB)", 2D) = "white" { }
 		_IsLinear ("Is Linear (1 = true)", Float) = 0
 	}
-	SubShader{
-		Pass{
-		ZWrite Off
-		ZTest Always
-		Cull Off
-		//Blend SrcAlpha OneMinusSrcAlpha
-//		Blend One One
-		CGPROGRAM
-#pragma vertex vert
-#pragma fragment frag
-#include "UnityShaderVariables.cginc"
-
-		// uniforms
-		float4 _MainTex_ST;
-
-
-		// vertex shader input data
-	struct appdata {
-		float3 pos : POSITION;
-		half4 color : COLOR;
-		float3 uv0 : TEXCOORD0;
-	};
-
-	// vertex-to-fragment interpolators
-	struct v2f {
-		fixed4 color : COLOR0;
-		float2 uv0 : TEXCOORD0;
-		float4 pos : SV_POSITION;
-	};
-
-	// vertex shader
-	v2f vert(appdata IN) {
-		v2f o;
-		half4 color = IN.color;
-		half3 viewDir = 0.0;
-		o.color = saturate(color);
-		// compute texture coordinates
-		o.uv0 = IN.uv0.xy * _MainTex_ST.xy + _MainTex_ST.zw;
-		// transform position
-		o.pos = mul(UNITY_MATRIX_MVP, float4(IN.pos,1));
-		return o;
-	}
-
-	// textures
-	sampler2D _MainTex;
-	float _IsLinear;
-
-	fixed4 frag(v2f IN) : SV_Target
+	SubShader
 	{
-		fixed4 col;
-		fixed4 tex, tmp0, tmp1, tmp2;
-		// SetTexture #0
-		tex = tex2D(_MainTex, IN.uv0.xy);
-		col = IN.color * tex;
-
-		if(_IsLinear > 0)
+		Pass
 		{
-//			col = pow(col, 0.47);
-			col = pow(col, 0.454545);
-			
-		}
-		col.a = 1;
+			ZWrite Off
+			ZTest Always
+			Cull Off
+			CGPROGRAM
+				#pragma vertex vert
+				#pragma fragment frag
+				#include "UnityShaderVariables.cginc"
 
-		return col;
-	}
-		ENDCG
-	}
+				// uniforms
+				float4 _MainTex_ST;
+
+				// vertex shader input data
+				struct appdata
+				{
+					float3 pos : POSITION;
+					half4 color : COLOR;
+					float3 uv0 : TEXCOORD0;
+				};
+
+				// vertex-to-fragment interpolators
+				struct v2f
+				{
+					fixed4 color : COLOR0;
+					float2 uv0 : TEXCOORD0;
+					float4 pos : SV_POSITION;
+				};
+
+				// vertex shader
+				v2f vert(appdata IN)
+				{
+					v2f o;
+					half4 color = IN.color;
+					half3 viewDir = 0.0;
+					o.color = saturate(color);
+					// compute texture coordinates
+					o.uv0 = IN.uv0.xy * _MainTex_ST.xy + _MainTex_ST.zw;
+					// transform position
+					o.pos = UnityObjectToClipPos(float4(IN.pos,1));
+					return o;
+				}
+
+				// textures
+				sampler2D _MainTex;
+				float _IsLinear;
+
+				fixed4 frag(v2f IN) : SV_Target
+				{
+					fixed4 col;
+					fixed4 tex, tmp0, tmp1, tmp2;
+					// SetTexture #0
+					tex = tex2D(_MainTex, IN.uv0.xy);
+					col = IN.color * tex;
+
+					if(_IsLinear > 0)
+					{
+						// col = pow(col, 0.47);
+						col = pow(col, 0.454545);
+					}
+					col.a = 1;
+
+					return col;
+				}
+			ENDCG
+		}
 	}
 }

--- a/Shaders/SeeExcluded.shader
+++ b/Shaders/SeeExcluded.shader
@@ -42,7 +42,7 @@ Shader "SabreCSG/SeeExcluded"
 					o.worldPos = IN.pos;
 					o.worldNormal = IN.normal;
 					// transform position
-					o.pos = UnityObjectToClipPos(float4(IN.pos,1));
+					o.pos = mul(UNITY_MATRIX_MVP, float4(IN.pos,1));
 					return o;
 				}
 

--- a/Shaders/SeeExcluded.shader
+++ b/Shaders/SeeExcluded.shader
@@ -1,115 +1,75 @@
 ﻿// Derived from an original shader by Robert Yang, used with permission
-Shader "SabreCSG/SeeExcluded" {
-  Properties {
+Shader "SabreCSG/SeeExcluded"
+{
+	Properties
+	{
 		_MainTex("Side", 2D) = "white" {}
 	}
-	SubShader{
-		Pass{
-		ZWrite Off
-//		Cull Off
-		Blend SrcAlpha OneMinusSrcAlpha
-		CGPROGRAM
-#pragma vertex vert
-#pragma fragment frag
-#include "UnityShaderVariables.cginc"
 
-		// uniforms
-			sampler2D _MainTex;
+	SubShader
+	{
+		Pass
+		{
+			ZWrite Off
+			Blend SrcAlpha OneMinusSrcAlpha
+			CGPROGRAM
+				#pragma vertex vert
+				#pragma fragment frag
+				#include "UnityShaderVariables.cginc"
 
-		// vertex shader input data
-	struct appdata {
-		float3 pos : POSITION;
-		float3 normal : NORMAL;
-	};
+				// uniforms
+				sampler2D _MainTex;
 
-	// vertex-to-fragment interpolators
-	struct v2f {
-		float4 pos : SV_POSITION;
-		float3 worldPos : TEXCOORD0;
-		float3 worldNormal : TEXCOORD1;
-	};
+				// vertex shader input data
+				struct appdata
+				{
+					float3 pos : POSITION;
+					float3 normal : NORMAL;
+				};
 
-	// vertex shader
-	v2f vert(appdata IN) {
-		v2f o;
-		o.worldPos = IN.pos;
-		o.worldNormal = IN.normal;
-		// transform position
-		o.pos = mul(UNITY_MATRIX_MVP, float4(IN.pos,1));
-		return o;
-	}
+				// vertex-to-fragment interpolators
+				struct v2f
+				{
+					float4 pos : SV_POSITION;
+					float3 worldPos : TEXCOORD0;
+					float3 worldNormal : TEXCOORD1;
+				};
 
-	// fragment shader
-	fixed4 frag(v2f IN) : SV_Target{
+				// vertex shader
+				v2f vert(appdata IN)
+				{
+					v2f o;
+					o.worldPos = IN.pos;
+					o.worldNormal = IN.normal;
+					// transform position
+					o.pos = UnityObjectToClipPos(float4(IN.pos,1));
+					return o;
+				}
 
-	float3 result;
+				// fragment shader
+				fixed4 frag(v2f IN) : SV_Target
+				{
+					float3 result;
 
+					float3 projNormal = saturate(pow(IN.worldNormal * 1.4, 4));
 
-	float3 projNormal = saturate(pow(IN.worldNormal * 1.4, 4));
+					float scale = 1;//0.5f;
+					// SIDE X
+					float3 x = tex2D(_MainTex, IN.worldPos.zy * scale) * abs(IN.worldNormal.x);
 
-	float scale = 1;//0.5f;
-	// SIDE X
-	float3 x = tex2D(_MainTex, IN.worldPos.zy * scale) * abs(IN.worldNormal.x);
+					// TOP / BOTTOM
+					float3 y = tex2D(_MainTex, IN.worldPos.zx * scale) * abs(IN.worldNormal.y);
 
-	// TOP / BOTTOM
-	float3 y = tex2D(_MainTex, IN.worldPos.zx * scale) * abs(IN.worldNormal.y);
+					// SIDE Z	
+					float3 z = tex2D(_MainTex, IN.worldPos.xy * scale) * abs(IN.worldNormal.z);
 
-	// SIDE Z	
-	float3 z = tex2D(_MainTex, IN.worldPos.xy * scale) * abs(IN.worldNormal.z);
+					result = z;
+					result = lerp(result, x, projNormal.x);
+					result = lerp(result, y, projNormal.y);
 
-	result = z;
-	result = lerp(result, x, projNormal.x);
-	result = lerp(result, y, projNormal.y);
-
-
-
-	return fixed4(result, 0.5);
-
-
-
-
-
-
-
-
-	}
-		ENDCG
-	}
+					return fixed4(result, 0.5);
+				}
+			ENDCG
+		}
 	}
 }
-
-//
-//
-//
-//Shader "SabreCSG/SeeExcluded" {
-//
-//	
-//	SubShader {
-//		Tags {
-//			"Queue"="Geometry"
-//			"IgnoreProjector"="False"
-//			"RenderType"="Opaque"
-//		}
-//
-//		Cull Back
-//		ZWrite On
-//		
-//		CGPROGRAM
-//		#pragma surface surf Lambert
-//		#pragma exclude_renderers flash
-//
-//		sampler2D _MainTex;
-//		float _Scale;
-//		
-//		struct Input {
-//			float3 worldPos;
-//			float3 worldNormal;
-//		};
-//			
-//		void surf (Input IN, inout SurfaceOutput o) {
-//			
-//		} 
-//		ENDCG
-//	}
-//	Fallback "Diffuse"
-//}

--- a/Shaders/ShapeEditorGrid.shader
+++ b/Shaders/ShapeEditorGrid.shader
@@ -41,7 +41,7 @@
 				v2f vert(appdata IN)
 				{
 					v2f o;
-					o.pos = UnityObjectToClipPos(float4(IN.pos,1));
+					o.pos = mul(UNITY_MATRIX_MVP, float4(IN.pos,1));
 					return o;
 				}
 

--- a/Shaders/ShapeEditorLine.shader
+++ b/Shaders/ShapeEditorLine.shader
@@ -38,7 +38,7 @@
 					o.color = saturate(color);
 					// compute texture coordinates
 					// transform position
-					o.pos = UnityObjectToClipPos(float4(IN.pos,1));
+					o.pos = mul(UNITY_MATRIX_MVP, float4(IN.pos,1));
 					return o;
 				}
 

--- a/Shaders/ShapeEditorLine.shader
+++ b/Shaders/ShapeEditorLine.shader
@@ -1,52 +1,57 @@
-﻿// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+﻿Shader "SabreCSG/ShapeEditorLine"
+{
+	SubShader
+	{
+		Pass
+		{
+			ZWrite Off
+			Cull Off
+			Blend SrcAlpha OneMinusSrcAlpha
+			CGPROGRAM
+				#pragma vertex vert
+				#pragma fragment frag
+				#include "UnityCG.cginc"
+				#include "UnityShaderVariables.cginc"
 
-Shader "SabreCSG/ShapeEditorLine" {
-	SubShader{
-		Pass{
-		ZWrite Off
-		Cull Off
-		Blend SrcAlpha OneMinusSrcAlpha
-		CGPROGRAM
-#pragma vertex vert
-#pragma fragment frag
-#include "UnityCG.cginc"
-#include "UnityShaderVariables.cginc"
+				// uniforms
 
-	// uniforms
+				// vertex shader input data
+				struct appdata
+				{
+					float3 pos : POSITION;
+					half4 color : COLOR;
+				};
 
-	// vertex shader input data
-	struct appdata {
-		float3 pos : POSITION;
-		half4 color : COLOR;
-	};
+				// vertex-to-fragment interpolators
+				struct v2f
+				{
+					fixed4 color : COLOR0;
+					float4 pos : SV_POSITION;
+				};
 
-	// vertex-to-fragment interpolators
-	struct v2f {
-		fixed4 color : COLOR0;
-		float4 pos : SV_POSITION;
-	};
+				// vertex shader
+				v2f vert(appdata IN)
+				{
+					v2f o;
+					half4 color = IN.color;
+					half3 viewDir = 0.0;
+					o.color = saturate(color);
+					// compute texture coordinates
+					// transform position
+					o.pos = UnityObjectToClipPos(float4(IN.pos,1));
+					return o;
+				}
 
-	// vertex shader
-	v2f vert(appdata IN) {
-		v2f o;
-		half4 color = IN.color;
-		half3 viewDir = 0.0;
-		o.color = saturate(color);
-		// compute texture coordinates
-		// transform position
-		o.pos = UnityObjectToClipPos(float4(IN.pos,1));
-		return o;
-	}
-
-	// fragment shader
-	fixed4 frag(v2f IN) : SV_Target {
-		fixed4 col;
-		col = IN.color;
-		if (IN.pos.y < 35)
-			discard;
-		return col;
-	}
-		ENDCG
-	}
+				// fragment shader
+				fixed4 frag(v2f IN) : SV_Target
+				{
+					fixed4 col;
+					col = IN.color;
+					if (IN.pos.y < 35)
+					discard;
+					return col;
+				}
+			ENDCG
+		}
 	}
 }

--- a/Shaders/Tri-Planar.shader
+++ b/Shaders/Tri-Planar.shader
@@ -1,6 +1,8 @@
 ﻿// Original shader by Robert Yang
-Shader "SabreCSG/Tri-Planar World" {
-  Properties {
+Shader "SabreCSG/Tri-Planar World"
+{
+	Properties
+	{
 		_Side("Side", 2D) = "white" {}
 		_Top("Top", 2D) = "white" {}
 		_Bottom("Bottom", 2D) = "white" {}
@@ -9,49 +11,47 @@ Shader "SabreCSG/Tri-Planar World" {
 		_BottomScale ("Bottom Scale", Float) = 2
 	}
 	
-	SubShader {
-		Tags {
-			"Queue"="Geometry"
-			"IgnoreProjector"="False"
-			"RenderType"="Opaque"
-		}
+	SubShader
+	{
+		Tags { "Queue"="Geometry" "IgnoreProjector"="False" "RenderType"="Opaque" }
 
 		Cull Back
 		ZWrite On
 		
 		CGPROGRAM
-		#pragma surface surf Lambert
-		#pragma exclude_renderers flash
+			#pragma surface surf Lambert
+			#pragma exclude_renderers flash
 
-		sampler2D _Side, _Top, _Bottom;
-		float _SideScale, _TopScale, _BottomScale;
+			sampler2D _Side, _Top, _Bottom;
+			float _SideScale, _TopScale, _BottomScale;
 		
-		struct Input {
-			float3 worldPos;
-			float3 worldNormal;
-		};
+			struct Input
+			{
+				float3 worldPos;
+				float3 worldNormal;
+			};
 			
-		void surf (Input IN, inout SurfaceOutput o) {
-			float3 projNormal = saturate(pow(IN.worldNormal * 1.4, 4));
+			void surf (Input IN, inout SurfaceOutput o)
+			{
+				float3 projNormal = saturate(pow(IN.worldNormal * 1.4, 4));
 			
-			// SIDE X
-			float3 x = tex2D(_Side, frac(IN.worldPos.zy * _SideScale)) * abs(IN.worldNormal.x);
+				// SIDE X
+				float3 x = tex2D(_Side, frac(IN.worldPos.zy * _SideScale)) * abs(IN.worldNormal.x);
 			
-			// TOP / BOTTOM
-			float3 y = 0;
-			if (IN.worldNormal.y > 0) {
-				y = tex2D(_Top, frac(IN.worldPos.zx * _TopScale)) * abs(IN.worldNormal.y);
-			} else {
-				y = tex2D(_Bottom, frac(IN.worldPos.zx * _BottomScale)) * abs(IN.worldNormal.y);
-			}
+				// TOP / BOTTOM
+				float3 y = 0;
+				if (IN.worldNormal.y > 0)
+					y = tex2D(_Top, frac(IN.worldPos.zx * _TopScale)) * abs(IN.worldNormal.y);
+				else
+					y = tex2D(_Bottom, frac(IN.worldPos.zx * _BottomScale)) * abs(IN.worldNormal.y);
 			
-			// SIDE Z	
-			float3 z = tex2D(_Side, frac(IN.worldPos.xy * _SideScale)) * abs(IN.worldNormal.z);
+				// SIDE Z	
+				float3 z = tex2D(_Side, frac(IN.worldPos.xy * _SideScale)) * abs(IN.worldNormal.z);
 			
-			o.Albedo = z;
-			o.Albedo = lerp(o.Albedo, x, projNormal.x);
-			o.Albedo = lerp(o.Albedo, y, projNormal.y);
-		} 
+				o.Albedo = z;
+				o.Albedo = lerp(o.Albedo, x, projNormal.x);
+				o.Albedo = lerp(o.Albedo, y, projNormal.y);
+			} 
 		ENDCG
 	}
 	Fallback "Diffuse"

--- a/Shaders/UINoAlpha.shader
+++ b/Shaders/UINoAlpha.shader
@@ -45,7 +45,7 @@
 					// compute texture coordinates
 					o.uv0 = IN.uv0.xy * _MainTex_ST.xy + _MainTex_ST.zw;
 					// transform position
-					o.pos = UnityObjectToClipPos(float4(IN.pos,1));
+					o.pos = mul(UNITY_MATRIX_MVP, float4(IN.pos,1));
 					return o;
 				}
 

--- a/Shaders/UINoAlpha.shader
+++ b/Shaders/UINoAlpha.shader
@@ -1,62 +1,68 @@
-﻿Shader "SabreCSG/UI No Alpha" {
-Properties{
+﻿Shader "SabreCSG/UI No Alpha"
+{
+	Properties
+	{
 		_MainTex("Base (RGB)", 2D) = "white" { }
 	}
-	SubShader{
-		Pass{
-		ZWrite Off
-		Cull Off
-		Blend SrcAlpha OneMinusSrcAlpha
-		CGPROGRAM
-#pragma vertex vert
-#pragma fragment frag
-#include "UnityShaderVariables.cginc"
-
-		// uniforms
-		float4 _MainTex_ST;
-
-		// vertex shader input data
-	struct appdata {
-		float3 pos : POSITION;
-		half4 color : COLOR;
-		float3 uv0 : TEXCOORD0;
-	};
-
-	// vertex-to-fragment interpolators
-	struct v2f {
-		fixed4 color : COLOR0;
-		float2 uv0 : TEXCOORD0;
-		float4 pos : SV_POSITION;
-	};
-
-	// vertex shader
-	v2f vert(appdata IN) {
-		v2f o;
-		half4 color = IN.color;
-		half3 viewDir = 0.0;
-		o.color = saturate(color);
-		// compute texture coordinates
-		o.uv0 = IN.uv0.xy * _MainTex_ST.xy + _MainTex_ST.zw;
-		// transform position
-		o.pos = mul(UNITY_MATRIX_MVP, float4(IN.pos,1));
-		return o;
-	}
-
-	// textures
-	sampler2D _MainTex;
-
-
-	fixed4 frag(v2f IN) : SV_Target
+	SubShader
 	{
-		fixed4 col;
-		fixed4 tex, tmp0, tmp1, tmp2;
-		// SetTexture #0
-		tex = tex2D(_MainTex, IN.uv0.xy);
-		col = IN.color * tex;
-//		col.a = 1;
-		return col;
-	}
-		ENDCG
-	}
+		Pass
+		{
+			ZWrite Off
+			Cull Off
+			Blend SrcAlpha OneMinusSrcAlpha
+			CGPROGRAM
+				#pragma vertex vert
+				#pragma fragment frag
+				#include "UnityShaderVariables.cginc"
+
+				// uniforms
+				float4 _MainTex_ST;
+
+				// vertex shader input data
+				struct appdata
+				{
+					float3 pos : POSITION;
+					half4 color : COLOR;
+					float3 uv0 : TEXCOORD0;
+				};
+
+				// vertex-to-fragment interpolators
+				struct v2f
+				{
+					fixed4 color : COLOR0;
+					float2 uv0 : TEXCOORD0;
+					float4 pos : SV_POSITION;
+				};
+
+				// vertex shader
+				v2f vert(appdata IN)
+				{
+					v2f o;
+					half4 color = IN.color;
+					half3 viewDir = 0.0;
+					o.color = saturate(color);
+					// compute texture coordinates
+					o.uv0 = IN.uv0.xy * _MainTex_ST.xy + _MainTex_ST.zw;
+					// transform position
+					o.pos = UnityObjectToClipPos(float4(IN.pos,1));
+					return o;
+				}
+
+				// textures
+				sampler2D _MainTex;
+
+				fixed4 frag(v2f IN) : SV_Target
+				{
+					fixed4 col;
+					fixed4 tex, tmp0, tmp1, tmp2;
+					// SetTexture #0
+					tex = tex2D(_MainTex, IN.uv0.xy);
+					col = IN.color * tex;
+					// col.a = 1;
+					return col;
+				}
+			ENDCG
+		}
 	}
 }

--- a/Shaders/VertexTinted.shader
+++ b/Shaders/VertexTinted.shader
@@ -1,39 +1,44 @@
-﻿Shader "SabreCSG/Vertex Tinted" {
-	Properties {
+﻿Shader "SabreCSG/Vertex Tinted"
+{
+	Properties
+	{
 		_MainTex ("Albedo (RGB)", 2D) = "white" {}
 		_Glossiness ("Smoothness", Range(0,1)) = 0.5
 		_Metallic ("Metallic", Range(0,1)) = 0.0
 	}
-	SubShader {
+	SubShader
+	{
 		Tags { "RenderType"="Opaque" }
 		LOD 200
 		
 		CGPROGRAM
-		// Physically based Standard lighting model, and enable shadows on all light types
-		#pragma surface surf Standard fullforwardshadows
+			// Physically based Standard lighting model, and enable shadows on all light types
+			#pragma surface surf Standard fullforwardshadows
 
-		// Use shader model 3.0 target, to get nicer looking lighting
-		#pragma target 3.0
+			// Use shader model 3.0 target, to get nicer looking lighting
+			#pragma target 3.0
 
-		sampler2D _MainTex;
+			sampler2D _MainTex;
 
-		struct Input {
-			float2 uv_MainTex;
-			fixed4 color : COLOR;
-		};
+			struct Input
+			{
+				float2 uv_MainTex;
+				fixed4 color : COLOR;
+			};
 
-		half _Glossiness;
-		half _Metallic;
+			half _Glossiness;
+			half _Metallic;
 
-		void surf (Input IN, inout SurfaceOutputStandard o) {
-			// Albedo comes from a texture tinted by color
-			fixed4 c = tex2D (_MainTex, IN.uv_MainTex);
-			o.Albedo = lerp(fixed3(1,1,1), IN.color, saturate((1-c.rgb)*2));
-			// Metallic and smoothness come from slider variables
-			o.Metallic = _Metallic;
-			o.Smoothness = _Glossiness;
-			o.Alpha = c.a;
-		}
+			void surf (Input IN, inout SurfaceOutputStandard o)
+			{
+				// Albedo comes from a texture tinted by color
+				fixed4 c = tex2D (_MainTex, IN.uv_MainTex);
+				o.Albedo = lerp(fixed3(1,1,1), IN.color, saturate((1-c.rgb)*2));
+				// Metallic and smoothness come from slider variables
+				o.Metallic = _Metallic;
+				o.Smoothness = _Glossiness;
+				o.Alpha = c.a;
+			}
 		ENDCG
 	}
 	FallBack "Diffuse"


### PR DESCRIPTION
- Cleaned up the source code of all of the shaders (edit: indentation and line breaks only).
- Removed warnings about "There are inconsistent line endings".
- Took care of "Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'"