### PR TITLE
Now hiding several compound brushes from the "..." list.

### DIFF
--- a/Scripts/Brushes/CompoundBrush.cs
+++ b/Scripts/Brushes/CompoundBrush.cs
@@ -218,8 +218,13 @@ namespace Sabresaurus.SabreCSG
 						// If the Type inherits from CompoundBrush and is not abstract
 						if(!types[i].IsAbstract && types[i].IsSubclassOf(typeof(CompoundBrush)))
 						{
-							// Valid compound brush type found!
-							matchedTypes.Add(types[i]);
+                            // List of exceptions that already have an icon in the toolbar
+                            if (types[i] == typeof(StairBrush)) continue;
+                            if (types[i] == typeof(CurvedStairBrush)) continue;
+                            if (types[i] == typeof(ShapeEditor.ShapeEditorBrush)) continue;
+
+                            // Valid compound brush type found!
+                            matchedTypes.Add(types[i]);
 						}
 					}
 				}

--- a/Scripts/Brushes/CompoundBrushes/Editor/TrimBrushInspector.cs.meta
+++ b/Scripts/Brushes/CompoundBrushes/Editor/TrimBrushInspector.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 52521b88423da6845a18d918cd0f47ab
+timeCreated: 1520760969
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Brushes/CompoundBrushes/TrimBrush.cs.meta
+++ b/Scripts/Brushes/CompoundBrushes/TrimBrush.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 94244af071e1c8941b9d5d54afe80deb
+timeCreated: 1520760969
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/UI/Toolbar.cs
+++ b/Scripts/UI/Toolbar.cs
@@ -405,6 +405,10 @@ namespace Sabresaurus.SabreCSG
 					menu.AddItem (new GUIContent (compoundBrushTypes[i].Name), false, CreateCompoundBrush, compoundBrushTypes[i]);
 				}
 
+                menu.AddSeparator("");
+                
+                menu.AddItem(new GUIContent("Add More?"), false, () => { EditorUtility.DisplayDialog("SabreCSG - About Compound Brushes", "Any custom compound brushes in your project are automatically detected and added to this list. Simply inherit from 'Sabresaurus.SabreCSG.CompoundBrush'.", "Okay"); });
+
 				menu.DropDown(new Rect(60,createBrushStyle.fixedHeight, 100, createBrushStyle.fixedHeight));
 			}
 


### PR DESCRIPTION
Now that we finally have a compound brush that isn't accessible using a toolbar icon, we just hide the Stair/CurvedStair/ShapeEditor-Compound Brushes from the "..." list. It will simply show custom stuff we don't know about and the Trim brush.

I also took the time to add a menu item explaining how to add your own compound brushes to the list which may also inspire more people to give it a shot.