### PR TITLE
Improved follow last face user friendliness. Fixes #67.

### DIFF
--- a/Scripts/Tools/SurfaceEditor.cs
+++ b/Scripts/Tools/SurfaceEditor.cs
@@ -391,7 +391,8 @@ namespace Sabresaurus.SabreCSG
                 }
 
                 selectedSourcePolygons.Add(currentPolygon);
-                matchedBrushes.Add(currentPolygon, csgModel.FindBrushFromPolygon(currentPolygon));
+                if (!matchedBrushes.ContainsKey(currentPolygon))
+                    matchedBrushes.Add(currentPolygon, csgModel.FindBrushFromPolygon(currentPolygon));
                 lastSelectedPolygon = currentPolygon;
             }
         }

--- a/Scripts/Tools/SurfaceEditor.cs
+++ b/Scripts/Tools/SurfaceEditor.cs
@@ -137,8 +137,6 @@ namespace Sabresaurus.SabreCSG
 		void OnMouseDown (SceneView sceneView, Event e)
 		{
 			if(e.button != 0
-				//|| (SabreInput.AnyModifiersSet(e) && !(SabreInput.IsModifier(e, EventModifiers.Control) || SabreInput.IsModifier(e, EventModifiers.Shift)) || SabreInput.IsModifier(e, EventModifiers.Control | EventModifiers.Shift))
-				|| (!SabreInput.AnyModifiersSet(e) || !(SabreInput.IsModifier(e, EventModifiers.Control) || SabreInput.IsModifier(e, EventModifiers.Shift) || SabreInput.IsModifier(e, EventModifiers.Control | EventModifiers.Shift)))
                 || CameraPanInProgress
 				|| EditorHelper.IsMousePositionInIMGUIRect(e.mousePosition, ToolbarRect))
 			{


### PR DESCRIPTION
* Hold the left mouse down to follow last faces easily.
* No more error spam in the console about dictionaries and null reference exceptions.
* A couple more general fixes in the surface editor that caused errors in the console.

![followfaceimproved](https://user-images.githubusercontent.com/7905726/37830696-3d1e3db0-2ea3-11e8-806a-5c8e6f313509.gif)

This feature cleans up curved UVs and fixes #67.