### PR TITLE
Brushes now get auto-generated names. Fixes #75.

### DIFF
--- a/Scripts/Brushes/CompoundBrush.cs
+++ b/Scripts/Brushes/CompoundBrush.cs
@@ -42,7 +42,19 @@ namespace Sabresaurus.SabreCSG
 			return parentCsgModel;
 		}
 
-		protected virtual void Start()
+        /// <summary>
+        /// Gets the beautiful name of the brush used in auto-generation of the hierarchy name.
+        /// </summary>
+        /// <value>The beautiful name of the brush.</value>
+        public override string BeautifulBrushName
+        {
+            get
+            {
+                return GetType().Name;
+            }
+        }
+
+        protected virtual void Start()
 		{
 			generatedBrushes = new List<PrimitiveBrush>(GetComponentsInChildren<PrimitiveBrush>());
 			for (int i = 0; i < generatedBrushes.Count; i++) 
@@ -53,6 +65,8 @@ namespace Sabresaurus.SabreCSG
 
 		public override void Invalidate (bool polygonsChanged)
 		{
+            base.Invalidate(polygonsChanged);
+
 			generatedBrushes.RemoveAll(item => item == null);
 			if(generatedBrushes.Count > BrushCount)
 			{

--- a/Scripts/Brushes/CompoundBrushes/CurvedStairBrush.cs
+++ b/Scripts/Brushes/CompoundBrushes/CurvedStairBrush.cs
@@ -129,8 +129,21 @@ namespace Sabresaurus.SabreCSG
         /// <summary>The last known position of the compound brush to prevent movement on resizing the bounds.</summary>
         private Vector3 m_LastKnownPosition;
 
-        void Awake()
+        /// <summary>
+        /// Gets the beautiful name of the brush used in auto-generation of the hierarchy name.
+        /// </summary>
+        /// <value>The beautiful name of the brush.</value>
+        public override string BeautifulBrushName
         {
+            get
+            {
+                return "Curved Stairs Brush";
+            }
+        }
+
+        protected override void Awake()
+        {
+            base.Awake();
             // get the last known extents and position (especially after scene changes).
             m_LastKnownExtents = localBounds.extents;
             m_LastKnownPosition = transform.localPosition;
@@ -151,7 +164,7 @@ namespace Sabresaurus.SabreCSG
 
 		public override void Invalidate (bool polygonsChanged)
 		{
-			base.Invalidate(polygonsChanged);
+            base.Invalidate(polygonsChanged);
 
             ////////////////////////////////////////////////////////////////////
             // a little hack to detect the user manually resizing the bounds. //
@@ -167,7 +180,7 @@ namespace Sabresaurus.SabreCSG
                 {                                                             //
                     numSteps += 1;                                            //
                     m_LastKnownExtents = localBounds.extents;                 //
-                    Invalidate(true); // recusion! <3                         //
+                    Invalidate(true); // recursion! <3                        //
                     return;                                                   //
                 }                                                             //
                 // user is trying to scale down.                              //
@@ -176,7 +189,7 @@ namespace Sabresaurus.SabreCSG
                     numSteps -= 1;                                            //
                     if (numSteps < 1) numSteps = 1;                           //
                     m_LastKnownExtents = localBounds.extents;                 //
-                    Invalidate(true); // recusion! <3                         //
+                    Invalidate(true); // recursion! <3                        //
                     return;                                                   //
                 }                                                             //
             }                                                                 //
@@ -524,6 +537,8 @@ namespace Sabresaurus.SabreCSG
             localBounds = csgBounds;
             m_LastKnownExtents = localBounds.extents;
             m_LastKnownPosition = transform.localPosition;
+            // update the generated name in the hierarchy.
+            UpdateGeneratedHierarchyName();
         }
 
         /// <summary>

--- a/Scripts/Brushes/CompoundBrushes/ShapeEditor/ShapeEditorBrush.cs
+++ b/Scripts/Brushes/CompoundBrushes/ShapeEditor/ShapeEditorBrush.cs
@@ -69,6 +69,18 @@ namespace Sabresaurus.SabreCSG.ShapeEditor
         [SerializeField]
         bool isDirty = true;
 
+        /// <summary>
+        /// Gets the beautiful name of the brush used in auto-generation of the hierarchy name.
+        /// </summary>
+        /// <value>The beautiful name of the brush.</value>
+        public override string BeautifulBrushName
+        {
+            get
+            {
+                return "2D Shape Editor Brush";
+            }
+        }
+
         /// <summary>The last known extents of the compound brush to detect user resizing the bounds.</summary>
         private Vector3 m_LastKnownExtents;
         /// <summary>The last known position of the compound brush to prevent movement on resizing the bounds.</summary>
@@ -80,8 +92,9 @@ namespace Sabresaurus.SabreCSG.ShapeEditor
         /// </summary>
         private List<Polygon> m_LastBuiltPolygons;
 
-        void Awake()
+        protected override void Awake()
         {
+            base.Awake();
             // get the last known extents and position (especially after scene changes).
             m_LastKnownExtents = localBounds.extents;
             m_LastKnownPosition = transform.localPosition;
@@ -267,6 +280,8 @@ namespace Sabresaurus.SabreCSG.ShapeEditor
             localBounds = csgBounds;
             m_LastKnownExtents = localBounds.extents;
             m_LastKnownPosition = transform.localPosition;
+            // update the generated name in the hierarchy.
+            UpdateGeneratedHierarchyName();
         }
 
         /// <summary>

--- a/Scripts/Brushes/CompoundBrushes/StairBrush.cs
+++ b/Scripts/Brushes/CompoundBrushes/StairBrush.cs
@@ -105,6 +105,18 @@ namespace Sabresaurus.SabreCSG
         /// <value><c>true</c> to fill steps to the bottom to make a solid staircase; otherwise, <c>false</c>.</value>
         public bool FillToBottom { get { return fillToBottom; } set { fillToBottom = value; } }
 
+        /// <summary>
+        /// Gets the beautiful name of the brush used in auto-generation of the hierarchy name.
+        /// </summary>
+        /// <value>The beautiful name of the brush.</value>
+        public override string BeautifulBrushName
+        {
+            get
+            {
+                return "Linear Stairs Brush";
+            }
+        }
+
         public override int BrushCount
 		{
 			get 

--- a/Scripts/Brushes/CompoundBrushes/TrimBrush.cs
+++ b/Scripts/Brushes/CompoundBrushes/TrimBrush.cs
@@ -21,6 +21,18 @@ namespace Sabresaurus.SabreCSG
         /// <value>The size of the trim.</value>
         public float TrimSize { get { return trimSize; } set { trimSize = value; } }
 
+        /// <summary>
+        /// Gets the beautiful name of the brush used in auto-generation of the hierarchy name.
+        /// </summary>
+        /// <value>The beautiful name of the brush.</value>
+        public override string BeautifulBrushName
+        {
+            get
+            {
+                return "Trim Brush";
+            }
+        }
+
         public override int BrushCount
 		{
 			get 

--- a/Scripts/Brushes/GroupBrush.cs
+++ b/Scripts/Brushes/GroupBrush.cs
@@ -24,13 +24,22 @@ namespace Sabresaurus.SabreCSG
         /// <value><c>true</c> if this brush supports CSG operations; otherwise, <c>false</c>.</value>
         public override bool SupportsCsgOperations { get { return false; } }
 
+        public override string BeautifulBrushName
+        {
+            get
+            {
+                return "Group";
+            }
+        }
+
         /// <summary>The last known extents of the compound brush to detect user resizing the bounds.</summary>
         private Vector3 m_LastKnownExtents;
         /// <summary>The last known position of the compound brush to prevent movement on resizing the bounds.</summary>
         private Vector3 m_LastKnownPosition;
 
-        void Awake()
+        protected override void Awake()
         {
+            base.Awake();
             // get the last known extents and position (especially after scene changes).
             m_LastKnownExtents = localBounds.extents;
             m_LastKnownPosition = transform.localPosition;
@@ -179,13 +188,15 @@ namespace Sabresaurus.SabreCSG
             localBounds = csgBounds;
             m_LastKnownExtents = localBounds.extents;
             m_LastKnownPosition = transform.localPosition;
+            // update name in hierarchy.
+            base.Invalidate(polygonsChanged);
         }
 
-        private void Update()
+        protected override void Update()
         {
+            base.Update();
             // encapsulate all of the child objects in our bounds.
             Bounds csgBounds = new Bounds();
-
             foreach (Transform childTransform in transform)
             {
                 BrushBase child = childTransform.GetComponent<BrushBase>();
@@ -194,6 +205,8 @@ namespace Sabresaurus.SabreCSG
             }
             // apply the generated csg bounds.
             localBounds = csgBounds;
+            // update the generated name in the hierarchy.
+            UpdateGeneratedHierarchyName();
         }
     }
 }

--- a/Scripts/Brushes/PrimitiveBrush.cs
+++ b/Scripts/Brushes/PrimitiveBrush.cs
@@ -136,7 +136,37 @@ namespace Sabresaurus.SabreCSG
 			}
 		}
 
-		public void SetBrushController(BrushBase brushController)
+        /// <summary>
+        /// Gets the beautiful name of the brush used in auto-generation of the hierarchy name.
+        /// </summary>
+        /// <value>The beautiful name of the brush.</value>
+        public override string BeautifulBrushName
+        {
+            get
+            {
+                switch (brushType)
+                {
+                    case PrimitiveBrushType.Cube:
+                        return "Cube Brush";
+                    case PrimitiveBrushType.Sphere:
+                        return "Sphere Brush";
+                    case PrimitiveBrushType.Cylinder:
+                        return "Cylinder Brush";
+                    case PrimitiveBrushType.Prism:
+                        return "Prism Brush";
+                    case PrimitiveBrushType.Custom:
+                        return "Custom Brush";
+                    case PrimitiveBrushType.IcoSphere:
+                        return "Icosphere Brush";
+                    case PrimitiveBrushType.Cone:
+                        return "Cone Brush";
+                    default:
+                        return base.BeautifulBrushName;
+                }
+            }
+        }
+
+        public void SetBrushController(BrushBase brushController)
 		{
 			this.brushController = brushController;
 		}
@@ -586,8 +616,10 @@ namespace Sabresaurus.SabreCSG
 			UpdateTracking();
 		}
 
-		void Update()
-		{
+        protected override void Update()
+        {
+            base.Update();
+
 			if(!tracked)
 			{
 				UpdateTracking();
@@ -727,7 +759,7 @@ namespace Sabresaurus.SabreCSG
 
         public override Bounds GetBounds()
         {
-			if (polygons.Length > 0)
+			if (polygons != null && polygons.Length > 0)
 			{
 				Bounds bounds = new Bounds(polygons[0].Vertices[0].Position, Vector3.zero);
 				

--- a/Scripts/CSGModelBase.cs
+++ b/Scripts/CSGModelBase.cs
@@ -550,7 +550,7 @@ namespace Sabresaurus.SabreCSG
 			}
 			else
 			{
-				brushObject = new GameObject("AppliedBrush");
+				brushObject = new GameObject("");
 			}
 
             brushObject.transform.localScale = this.transform.lossyScale;
@@ -581,7 +581,7 @@ namespace Sabresaurus.SabreCSG
 				SurfaceUtility.SetAllPolygonsMaterials(primitiveBrush, material);
 			}
 
-			return brushObject;
+            return brushObject;
 		}
 
 		public GameObject CreateCompoundBrush<T>(Vector3 localPosition, Vector3 localSize = default(Vector3), Quaternion localRotation = default(Quaternion), Material material = null, CSGMode csgMode = CSGMode.Add, string brushName = null) where T : CompoundBrush
@@ -604,7 +604,7 @@ namespace Sabresaurus.SabreCSG
 			}
 			else
 			{
-				brushObject = new GameObject(compoundBrushType.Name);
+				brushObject = new GameObject("");
 			}
 
             brushObject.transform.localScale = this.transform.lossyScale;
@@ -628,7 +628,7 @@ namespace Sabresaurus.SabreCSG
 //				SurfaceUtility.SetAllPolygonsMaterials(compoundBrush, material);
 			}
 
-			return brushObject;
+            return brushObject;
 		}
 
 		/// <summary>
@@ -638,7 +638,7 @@ namespace Sabresaurus.SabreCSG
 		/// <param name="polygons">Polygons.</param>
 		public GameObject CreateCustomBrush(Polygon[] polygons)
 		{
-			GameObject brushObject = new GameObject("AppliedBrush");
+			GameObject brushObject = new GameObject("");
 			brushObject.transform.parent = this.transform;
 			PrimitiveBrush primitiveBrush = brushObject.AddComponent<PrimitiveBrush>();
 			primitiveBrush.SetPolygons(polygons, true);

--- a/Scripts/Core/BrushBase.cs
+++ b/Scripts/Core/BrushBase.cs
@@ -10,6 +10,7 @@ using UnityEngine.Serialization;
 namespace Sabresaurus.SabreCSG
 {
 	public enum CSGMode { Add, Subtract };
+    [ExecuteInEditMode]
 	public abstract class BrushBase : MonoBehaviour
 	{
 		[SerializeField]
@@ -26,7 +27,9 @@ namespace Sabresaurus.SabreCSG
 
 		protected bool destroyed = false;
 
-		public CSGMode Mode
+        protected string previousHierarchyName = "";
+
+        public CSGMode Mode
 		{
 			get
 			{
@@ -88,6 +91,42 @@ namespace Sabresaurus.SabreCSG
 		}
 
         /// <summary>
+        /// Gets the beautiful name of the brush used in auto-generation of the hierarchy name.
+        /// </summary>
+        /// <value>The beautiful name of the brush.</value>
+        public virtual string BeautifulBrushName
+        {
+            get
+            {
+                return "AppliedBrush";
+            }
+        }
+
+        /// <summary>
+        /// Gets an auto-generated name for use in the hierarchy.
+        /// </summary>
+        /// <value>An auto-generated name for use in the hierarchy.</value>
+        public string GeneratedHierarchyName
+        {
+            get
+            {
+                return BeautifulBrushName + " (" + GetBounds().ToGeneratedHierarchyString() + ")";
+            }
+        }
+
+        /// <summary>
+        /// Updates the auto-generated name of the brush in the hierarchy. This must be called when
+        /// the bounds of a brush change without a call to <see cref="Invalidate"/>. The name of the
+        /// brush is not updated when the user changed it to something else manually. The only
+        /// exception to that is when the user resets the name to an empty string.
+        /// </summary>
+        public void UpdateGeneratedHierarchyName()
+        {
+            if (transform.name == previousHierarchyName || transform.name == "")
+                transform.name = previousHierarchyName = GeneratedHierarchyName;
+        }
+
+        /// <summary>
         /// Gets a value indicating whether this brush supports CSG operations. Setting this to false
         /// will hide CSG brush related options in the editor.
         /// <para>For example a <see cref="GroupBrush"/> does not have any CSG operations.</para>
@@ -95,7 +134,12 @@ namespace Sabresaurus.SabreCSG
         /// <value><c>true</c> if this brush supports CSG operations; otherwise, <c>false</c>.</value>
         public virtual bool SupportsCsgOperations { get { return true; } }
 
-        public virtual void Invalidate(bool polygonsChanged){}
+        public virtual void Invalidate(bool polygonsChanged)
+        {
+            // when a modification to a brush occured we update the auto-generated name.
+            if (polygonsChanged)
+                UpdateGeneratedHierarchyName();
+        }
 
 		public abstract void UpdateVisibility();
 
@@ -110,11 +154,26 @@ namespace Sabresaurus.SabreCSG
         // Fired by the CSG Model on each brush it knows about when Unity triggers Undo.undoRedoPerformed
         public abstract void OnUndoRedoPerformed ();
 
-
 		protected virtual void OnDestroy()
 		{
 			destroyed = true;
-		}			
+		}
+
+        protected virtual void Awake()
+        {
+            // if the brush name is equal to the auto-generated one,
+            // we store the name so we can check for manual user changes.
+            if (previousHierarchyName == "" && GeneratedHierarchyName == transform.name)
+                previousHierarchyName = transform.name;
+        }
+
+        protected virtual void Update()
+        {
+            // if the brush name is equal to the auto-generated one,
+            // we store the name so we can check for manual user changes.
+            if (previousHierarchyName == "" && GeneratedHierarchyName == transform.name)
+                previousHierarchyName = transform.name;
+        }
 	}
 }
 

--- a/Scripts/Core/BrushBase.cs
+++ b/Scripts/Core/BrushBase.cs
@@ -167,14 +167,8 @@ namespace Sabresaurus.SabreCSG
                 previousHierarchyName = transform.name;
         }
 
-        protected virtual void Update()
-        {
-            // if the brush name is equal to the auto-generated one,
-            // we store the name so we can check for manual user changes.
-            if (previousHierarchyName == "" && GeneratedHierarchyName == transform.name)
-                previousHierarchyName = transform.name;
-        }
-	}
+        protected virtual void Update() { }
+    }
 }
 
 #endif

--- a/Scripts/Extensions/EditorHelper.cs
+++ b/Scripts/Extensions/EditorHelper.cs
@@ -373,9 +373,11 @@ namespace Sabresaurus.SabreCSG
 					Unsupported.DuplicateGameObjectsUsingPasteboard();
 					// Cache the new entry, so when we're done we reselect all new objects
 					newObjects[i] = Selection.activeGameObject;
-				}
-				// Finished duplicating, select all new objects
-				Selection.objects = newObjects;
+                    // Remove the 'Brush (1)', 'Brush (2)', etc. from the name.
+                    newObjects[i].name = Regex.Replace(newObjects[i].name, " \\(\\d+\\)$", "");
+                }
+                // Finished duplicating, select all new objects
+                Selection.objects = newObjects;
 			}
 
 			// Whether custom duplication took place and whether the Duplicate event should be consumed

--- a/Scripts/Extensions/Extensions.cs
+++ b/Scripts/Extensions/Extensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text;
 using UnityEngine;
 
@@ -412,6 +413,20 @@ namespace Sabresaurus.SabreCSG
                 && point.x < bounds1.max.x + EPSILON_LOWER_2
                 && point.y < bounds1.max.y + EPSILON_LOWER_2
                 && point.z < bounds1.max.z + EPSILON_LOWER_2);
+        }
+
+        /// <summary>
+        /// Creates a beautiful string that matches the numbers shown in the resize tool.
+        /// Used in the hierarchy.
+        /// </summary>
+        /// <param name="bounds">The bounds 'this' reference.</param>
+        /// <returns>The beautiful string.</returns>
+        internal static string ToGeneratedHierarchyString(this Bounds bounds)
+        {
+            string x = MathHelper.RoundFloat(bounds.size.x, 0.0001f).ToString(CultureInfo.InvariantCulture);
+            string y = MathHelper.RoundFloat(bounds.size.y, 0.0001f).ToString(CultureInfo.InvariantCulture);
+            string z = MathHelper.RoundFloat(bounds.size.z, 0.0001f).ToString(CultureInfo.InvariantCulture);
+            return x + " x " + y + " x " + z;
         }
     }
 }

--- a/Scripts/Extensions/TransformHelper.cs
+++ b/Scripts/Extensions/TransformHelper.cs
@@ -58,8 +58,8 @@ namespace Sabresaurus.SabreCSG
 				}
 
 				// Create group
-				GameObject groupObject = new GameObject("Group");
-                groupObject.AddComponent<GroupBrush>();
+				GameObject groupObject = new GameObject("");
+                GroupBrush groupBrush = groupObject.AddComponent<GroupBrush>();
 				Undo.RegisterCreatedObjectUndo (groupObject, "Group");
 				Undo.SetTransformParent(groupObject.transform, rootTransform, "Group");
 
@@ -74,6 +74,9 @@ namespace Sabresaurus.SabreCSG
 				{
 					Undo.SetTransformParent(selectedTransforms[i], groupObject.transform, "Group");
 				}
+
+                // Ensure it gets a correct name in the hierarchy.
+                groupBrush.UpdateGeneratedHierarchyName();
 
 				Selection.activeGameObject = groupObject;
 				//						EditorApplication.RepaintHierarchyWindow();

--- a/Scripts/Tools/SurfaceEditor.cs
+++ b/Scripts/Tools/SurfaceEditor.cs
@@ -2184,6 +2184,9 @@ namespace Sabresaurus.SabreCSG
 				newObject.transform.rotation = sourceBrush.transform.rotation * rotation;
 				// finally give the new brush the other set of polygons.
 				newObject.GetComponent<PrimitiveBrush>().SetPolygons(polygons, true);
+                // give the brush an appropriate auto-generated name.
+                newObject.name = "";
+                newObject.GetComponent<PrimitiveBrush>().UpdateGeneratedHierarchyName();
 
 				Undo.RegisterCreatedObjectUndo(newObject, "Extrude Brush");
 


### PR DESCRIPTION
# Auto Generated Brush Names

It creates clean brush names like:
* Cube Brush
* Sphere Brush
* Cylinder Brush
* Prism Brush
* Icosphere Brush
* Cone Brush
* Custom Brush
* Trim Brush
* Linear Stairs Brush
* Curved Stairs Brush
* 2D Shape Editor Brush

It then adds the bounds of the brush behind the name, for example:
* (2 x 2 x 2)
* (1.75 x 1 x 1)

**There's more!**
* Duplicated brushes no longer have "(1)", "(2)", "(3) (1)" behind their names.
* If you give a brush a custom name, it will stop auto-generating one.
* Just rename it to an empty string and it will auto-generate again.

Resulting in:

![Shows scene and hierarchy generating beautiful names](https://user-images.githubusercontent.com/7905726/38153300-41c19348-346c-11e8-9d9e-dc97c0109864.gif)

Fixes #75.