### PR TITLE
Compatibility update for older than Unity 2017.2. Fixes #80.

### DIFF
--- a/Scripts/Brushes/CompoundBrushes/Editor/ShapeEditorWindow.cs
+++ b/Scripts/Brushes/CompoundBrushes/Editor/ShapeEditorWindow.cs
@@ -986,7 +986,7 @@ namespace Sabresaurus.SabreCSG.ShapeEditor
         private void OnHome()
         {
             // scroll to the center of the screen.
-#if UNITY_5_4_OR_NEWER
+#if UNITY_2017_2_OR_NEWER
             viewportScroll = new Vector2(Screen.safeArea.width / 2.0f / EditorGUIUtility.pixelsPerPoint, Screen.safeArea.height / 2.0f / EditorGUIUtility.pixelsPerPoint);
 #else
             viewportScroll = new Vector2(Screen.width / 2.0f, Screen.height / 2.0f);
@@ -1346,7 +1346,7 @@ namespace Sabresaurus.SabreCSG.ShapeEditor
 
         private Rect GetViewportRect()
         {
-#if UNITY_5_4_OR_NEWER
+#if UNITY_2017_2_OR_NEWER
             Rect viewportRect = Screen.safeArea;
 #else
             Rect viewportRect = new Rect(0, 0, Screen.width, Screen.height);
@@ -1476,7 +1476,7 @@ namespace Sabresaurus.SabreCSG.ShapeEditor
         private void ShowCenteredPopupWindowContent(PopupWindowContent popup)
         {
             Vector2 size = popup.GetWindowSize();
-#if UNITY_5_4_OR_NEWER
+#if UNITY_2017_2_OR_NEWER
             PopupWindow.Show(new Rect((Screen.safeArea.width / 2.0f / EditorGUIUtility.pixelsPerPoint) - (size.x / 2.0f), (Screen.safeArea.height / 2.0f / EditorGUIUtility.pixelsPerPoint) - (size.y / 2.0f), 0, 0), popup);
 #else
             PopupWindow.Show(new Rect((Screen.width / 2.0f) - (size.x / 2.0f), (Screen.height / 2.0f) - (size.y / 2.0f), 0, 0), popup);


### PR DESCRIPTION
I added checks for UNITY_5_4_OR_NEWER not realizing that Screen.safeArea wasn't introduced until UNITY_2017_2_OR_NEWER. That has been fixed.

I am on vacation with my laptop, installed everything in a hurry and made a branch in the wrong repository, fantastic.