### PR TITLE
Vertex snapping for compound brushes and groups. Fixes #76.

### DIFF
--- a/Scripts/Brushes/GroupBrush.cs
+++ b/Scripts/Brushes/GroupBrush.cs
@@ -208,6 +208,50 @@ namespace Sabresaurus.SabreCSG
             // update the generated name in the hierarchy.
             UpdateGeneratedHierarchyName();
         }
+
+        /// <summary>
+        /// Gets all of the polygons from all brushes in this group brush.
+        /// </summary>
+        /// <returns>All of the polygons from all brushes in this group brush.</returns>
+        public Polygon[] GetPolygons()
+        {
+            List<Polygon> polygons = new List<Polygon>();
+            // iterate through all child brushes:
+            foreach (Brush brush in GetComponentsInChildren<Brush>())
+            {
+                polygons.AddRange(GenerateTransformedPolygons(brush.transform, brush.GetPolygons()));
+            }
+            return polygons.ToArray();
+        }
+
+        /// <summary>
+        /// Generates transformed polygons to match the group brush position.
+        /// </summary>
+        /// <param name="t">The transform of a child brush.</param>
+        /// <param name="polygons">The polygons of a child brush.</param>
+        /// <returns>The transformed polygons.</returns>
+        private Polygon[] GenerateTransformedPolygons(Transform t, Polygon[] polygons)
+        {
+            Polygon[] polygonsCopy = polygons.DeepCopy<Polygon>();
+
+            Vector3 center = t.localPosition;
+            Quaternion rotation = t.localRotation;
+            Vector3 scale = t.lossyScale;
+
+            for (int i = 0; i < polygonsCopy.Length; i++)
+            {
+                for (int j = 0; j < polygonsCopy[i].Vertices.Length; j++)
+                {
+                    polygonsCopy[i].Vertices[j].Position = rotation * polygonsCopy[i].Vertices[j].Position.Multiply(scale) + center;
+                    polygonsCopy[i].Vertices[j].Normal = rotation * polygonsCopy[i].Vertices[j].Normal;
+                }
+
+                // Just updated a load of vertex positions, so make sure the cached plane is updated
+                polygonsCopy[i].CalculatePlane();
+            }
+
+            return polygonsCopy;
+        }
     }
 }
 #endif

--- a/Scripts/Brushes/GroupBrush.cs
+++ b/Scripts/Brushes/GroupBrush.cs
@@ -4,6 +4,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using System.Reflection;
+using System.Linq;
 
 namespace Sabresaurus.SabreCSG
 {
@@ -217,9 +218,20 @@ namespace Sabresaurus.SabreCSG
         {
             List<Polygon> polygons = new List<Polygon>();
             // iterate through all child brushes:
-            foreach (Brush brush in GetComponentsInChildren<Brush>())
+            foreach (BrushBase brush in GetComponentsInChildren<BrushBase>().Where(c => c.transform != transform))
             {
-                polygons.AddRange(GenerateTransformedPolygons(brush.transform, brush.GetPolygons()));
+                Polygon[] polys;
+
+                // try getting the polygons depending on the brush type.
+                if (brush is PrimitiveBrush)
+                    polys = ((PrimitiveBrush)brush).GetPolygons();
+                else if (brush is CompoundBrush)
+                    polys = ((CompoundBrush)brush).GetPolygons();
+                else if (brush is GroupBrush)
+                    polys = ((GroupBrush)brush).GetPolygons();
+                else continue;
+
+                polygons.AddRange(GenerateTransformedPolygons(brush.transform, polys));
             }
             return polygons.ToArray();
         }

--- a/Scripts/Tools/ResizeEditor.cs
+++ b/Scripts/Tools/ResizeEditor.cs
@@ -2136,9 +2136,19 @@ namespace Sabresaurus.SabreCSG
             closestVertexWorldPosition = Vector3.zero;
             float closestDistanceSquare = float.PositiveInfinity;
 
-            foreach (PrimitiveBrush brush in targetBrushes)
+            foreach (BrushBase brush in targetBrushBases)
             {
-                Polygon[] polygons = brush.GetPolygons();
+                Polygon[] polygons;
+
+                // try getting the polygons depending on the brush type.
+                if (brush is PrimitiveBrush)
+                    polygons = ((PrimitiveBrush)brush).GetPolygons();
+                else if (brush is CompoundBrush)
+                    polygons = ((CompoundBrush)brush).GetPolygons();
+                else if (brush is GroupBrush)
+                    polygons = ((GroupBrush)brush).GetPolygons();
+                else continue;
+
                 for (int i = 0; i < polygons.Length; i++)
                 {
                     Polygon polygon = polygons[i];
@@ -2169,9 +2179,19 @@ namespace Sabresaurus.SabreCSG
                 closestVertexWorldPosition = Vector3.zero;
                 closestDistanceSquare = float.PositiveInfinity;
 
-                foreach (PrimitiveBrush brush in targetBrushes)
+                foreach (BrushBase brush in targetBrushBases)
                 {
-                    Polygon[] polygons = brush.GetPolygons();
+                    Polygon[] polygons;
+
+                    // try getting the polygons depending on the brush type.
+                    if (brush is PrimitiveBrush)
+                        polygons = ((PrimitiveBrush)brush).GetPolygons();
+                    else if (brush is CompoundBrush)
+                        polygons = ((CompoundBrush)brush).GetPolygons();
+                    else if (brush is GroupBrush)
+                        polygons = ((GroupBrush)brush).GetPolygons();
+                    else continue;
+
                     for (int i = 0; i < polygons.Length; i++)
                     {
                         Polygon polygon = polygons[i];


### PR DESCRIPTION
Attempting to vertex snap a compound brush or a group (in translate mode, holding V) will now work properly. Aligning stairs was never easier.