### PR TITLE
Playtesting no longer obliterates edit mode. Fixes #73.

### DIFF
--- a/Scripts/CSGModel.cs
+++ b/Scripts/CSGModel.cs
@@ -1268,6 +1268,9 @@ namespace Sabresaurus.SabreCSG
 			if(!EditorHelper.HasDelegate(Selection.selectionChanged, (Action)OnSelectionChanged))
 			{
 				Selection.selectionChanged += OnSelectionChanged;
+                // When we come out of play mode we lose this event handler and are no longer in edit mode.
+                // We call OnSelectionChanged() manually to make sure we go back into edit mode, if a brush is still selected.
+                OnSelectionChanged();
 			}
 #endif
 


### PR DESCRIPTION
When you have a brush selected because you edited something, start playing the game, stop playing the game, edit mode is gone until you select another brush or alike. This is now fixed by immediately checking the current selection once you come out of play-mode. Resulting in a seamless prototyping workflow.