### PR TITLE
2DSE: Added popup to set global pivot position. Fixes #69.

### DIFF
--- a/Scripts/Brushes/CompoundBrushes/Editor/ShapeEditorWindow.cs
+++ b/Scripts/Brushes/CompoundBrushes/Editor/ShapeEditorWindow.cs
@@ -743,8 +743,8 @@ namespace Sabresaurus.SabreCSG.ShapeEditor
                 GenericMenu toolsMenu = new GenericMenu();
                 toolsMenu.AddItem(new GUIContent("Background/Load Image..."), false, OnToolsBackgroundLoadImage);
                 toolsMenu.AddItem(new GUIContent("Background/Clear Background"), false, OnToolsBackgroundClearBackground);
-                toolsMenu.AddItem(new GUIContent("Pivot/Set Position..."), false, OnToolsPivotSetPosition);
-                toolsMenu.AddItem(new GUIContent("Pivot/Reset Position"), false, OnToolsPivotResetPosition);
+                toolsMenu.AddItem(new GUIContent("Global Pivot/Set Position..."), false, OnToolsPivotSetPosition);
+                toolsMenu.AddItem(new GUIContent("Global Pivot/Reset Position"), false, OnToolsPivotResetPosition);
 #if UNITY_5_4_OR_NEWER
                 toolsMenu.DropDown(new Rect((Screen.width - 50) / EditorGUIUtility.pixelsPerPoint, 0, 0, 16));
 #else

--- a/Scripts/Brushes/CompoundBrushes/Editor/ShapeEditorWindow.cs
+++ b/Scripts/Brushes/CompoundBrushes/Editor/ShapeEditorWindow.cs
@@ -743,6 +743,8 @@ namespace Sabresaurus.SabreCSG.ShapeEditor
                 GenericMenu toolsMenu = new GenericMenu();
                 toolsMenu.AddItem(new GUIContent("Background/Load Image..."), false, OnToolsBackgroundLoadImage);
                 toolsMenu.AddItem(new GUIContent("Background/Clear Background"), false, OnToolsBackgroundClearBackground);
+                toolsMenu.AddItem(new GUIContent("Pivot/Set Position..."), false, OnToolsPivotSetPosition);
+                toolsMenu.AddItem(new GUIContent("Pivot/Reset Position"), false, OnToolsPivotResetPosition);
 #if UNITY_5_4_OR_NEWER
                 toolsMenu.DropDown(new Rect((Screen.width - 50) / EditorGUIUtility.pixelsPerPoint, 0, 0, 16));
 #else
@@ -1344,6 +1346,29 @@ namespace Sabresaurus.SabreCSG.ShapeEditor
             backgroundImage = null;
         }
 
+        /// <summary>
+        /// Called when the tools 'menu/pivot/set position' item is pressed.
+        /// </summary>
+        private void OnToolsPivotSetPosition()
+        {
+            // let the user choose the global pivot position.
+            ShowCenteredPopupWindowContent(new ShapeEditorWindowPopup(ShapeEditorWindowPopup.PopupMode.GlobalPivotPosition, project, (self) => {
+                // set the new global pivot position.
+                project.globalPivot.position = self.GlobalPivotPosition_Position;
+
+                // show the changes.
+                Repaint();
+            }));
+        }
+
+        /// <summary>
+        /// Called when the tools 'menu/pivot/reset position' item is pressed.
+        /// </summary>
+        private void OnToolsPivotResetPosition()
+        {
+            project.globalPivot.position = Vector2Int.zero;
+        }
+
         private Rect GetViewportRect()
         {
 #if UNITY_2017_2_OR_NEWER
@@ -1476,11 +1501,15 @@ namespace Sabresaurus.SabreCSG.ShapeEditor
         private void ShowCenteredPopupWindowContent(PopupWindowContent popup)
         {
             Vector2 size = popup.GetWindowSize();
+            try
+            {
 #if UNITY_2017_2_OR_NEWER
-            PopupWindow.Show(new Rect((Screen.safeArea.width / 2.0f / EditorGUIUtility.pixelsPerPoint) - (size.x / 2.0f), (Screen.safeArea.height / 2.0f / EditorGUIUtility.pixelsPerPoint) - (size.y / 2.0f), 0, 0), popup);
+                PopupWindow.Show(new Rect((Screen.safeArea.width / 2.0f / EditorGUIUtility.pixelsPerPoint) - (size.x / 2.0f), (Screen.safeArea.height / 2.0f / EditorGUIUtility.pixelsPerPoint) - (size.y / 2.0f), 0, 0), popup);
 #else
-            PopupWindow.Show(new Rect((Screen.width / 2.0f) - (size.x / 2.0f), (Screen.height / 2.0f) - (size.y / 2.0f), 0, 0), popup);
+                PopupWindow.Show(new Rect((Screen.width / 2.0f) - (size.x / 2.0f), (Screen.height / 2.0f) - (size.y / 2.0f), 0, 0), popup);
 #endif
+            }
+            catch (ExitGUIException) { }
         }
 
         /// <summary>

--- a/Scripts/Brushes/CompoundBrushes/Editor/ShapeEditorWindowPopup.cs
+++ b/Scripts/Brushes/CompoundBrushes/Editor/ShapeEditorWindowPopup.cs
@@ -17,11 +17,12 @@ namespace Sabresaurus.SabreCSG
         public enum PopupMode
         {
             BezierDetailLevel,
+            GlobalPivotPosition,
             CreatePolygon,
             RevolveShape,
             ExtrudeShape,
             ExtrudePoint,
-            ExtrudeBevel
+            ExtrudeBevel,
         }
 
         private PopupMode popupMode;
@@ -32,6 +33,7 @@ namespace Sabresaurus.SabreCSG
         public Vector2 extrudeScale = Vector2.one;
         public int revolve360 = 8;
         public int revolveSteps = 4;
+        public Vector2Int GlobalPivotPosition_Position;
 
         private Action<ShapeEditorWindowPopup> onApply;
 
@@ -45,6 +47,7 @@ namespace Sabresaurus.SabreCSG
             extrudeScale = project.extrudeScale;
             revolve360 = project.revolve360;
             revolveSteps = project.revolveSteps;
+            GlobalPivotPosition_Position = project.globalPivot.position;
 
             this.onApply = (self) => {
 
@@ -86,6 +89,8 @@ namespace Sabresaurus.SabreCSG
             {
                 case PopupMode.BezierDetailLevel:
                     return new Vector2(205, 140);
+                case PopupMode.GlobalPivotPosition:
+                    return new Vector2(300, 50 + 18);
                 case PopupMode.CreatePolygon:
                     return new Vector2(300, 50 + 18);
                 case PopupMode.RevolveShape:
@@ -159,6 +164,22 @@ namespace Sabresaurus.SabreCSG
                     bezierDetailLevel_Detail = EditorGUILayout.IntField("Detail", bezierDetailLevel_Detail);
                     if (bezierDetailLevel_Detail < 1) bezierDetailLevel_Detail = 1;
                     if (bezierDetailLevel_Detail > 999) bezierDetailLevel_Detail = 999;
+                    break;
+
+                case PopupMode.GlobalPivotPosition:
+                    GUILayout.Label("Global Pivot Position", EditorStyles.boldLabel);
+                    hasScale = false;
+                    accept = "Set Position";
+
+#if !UNITY_2017_2_OR_NEWER
+                    EditorGUIUtility.wideMode = true;
+                    GlobalPivotPosition_Position = Vector2Int.FloorToInt(EditorGUILayout.Vector2Field("Position", GlobalPivotPosition_Position));
+                    EditorGUIUtility.wideMode = false;
+#else
+                    EditorGUIUtility.wideMode = true;
+                    GlobalPivotPosition_Position = EditorGUILayout.Vector2IntField("Position", GlobalPivotPosition_Position);
+                    EditorGUIUtility.wideMode = false;
+#endif
                     break;
 
                 case PopupMode.CreatePolygon:


### PR DESCRIPTION
If you have a super large revolved shape that spans the entire level. It would be a challenge to manually move the pivot so far away of the shape on the grid.

![New menu entries](https://user-images.githubusercontent.com/7905726/38336948-e0226170-3863-11e8-946d-ff02c13cd379.png)

![Set position window](https://user-images.githubusercontent.com/7905726/38336951-e392ca3e-3863-11e8-9552-32050ee62376.png)