### PR TITLE
Fixed that duplicated brushes stopped generating automatic names. Fixes #89.

### DIFF
--- a/Scripts/Core/BrushBase.cs
+++ b/Scripts/Core/BrushBase.cs
@@ -122,7 +122,7 @@ namespace Sabresaurus.SabreCSG
         /// </summary>
         public void UpdateGeneratedHierarchyName()
         {
-            if (transform.name == previousHierarchyName || transform.name == "")
+            if (transform.name == previousHierarchyName || transform.name == "" || previousHierarchyName == "")
                 transform.name = previousHierarchyName = GeneratedHierarchyName;
         }
 

--- a/Scripts/Core/BrushBase.cs
+++ b/Scripts/Core/BrushBase.cs
@@ -122,7 +122,11 @@ namespace Sabresaurus.SabreCSG
         /// </summary>
         public void UpdateGeneratedHierarchyName()
         {
-            if (transform.name == previousHierarchyName || transform.name == "" || previousHierarchyName == "")
+            // this may happen after the brush is duplicated.
+            if (previousHierarchyName == "" && GeneratedHierarchyName == transform.name)
+                previousHierarchyName = transform.name;
+
+            if (transform.name == previousHierarchyName || transform.name == "")
                 transform.name = previousHierarchyName = GeneratedHierarchyName;
         }
 


### PR DESCRIPTION
If you have a "Cube Brush (2 x 2 x 2)" and duplicate it, the duplicate will now update its name properly when you resize it.