### PR TITLE
Auto Rebuild responsiveness improvement with Resize tool.

### DIFF
--- a/Scripts/Tools/ResizeEditor.cs
+++ b/Scripts/Tools/ResizeEditor.cs
@@ -2086,10 +2086,20 @@ namespace Sabresaurus.SabreCSG
 			List<Transform> rootTransforms = TransformHelper.GetRootSelectionOnly(targetBrushTransforms);
 			Undo.RecordObjects(rootTransforms.ToArray(), "Move brush(es)");
 
-			for (int i = 0; i < rootTransforms.Count; i++) 
+            bool didAnyPositionChange = false;
+
+			for (int i = 0; i < rootTransforms.Count; i++)
 			{
-				targetBrushTransforms[i].position += worldDelta;
+                if (worldDelta != Vector3.zero)
+                {
+				    targetBrushTransforms[i].position += worldDelta;
+                    didAnyPositionChange = true;
+                }
 			}
+
+            // the user translated brushes but the grid snapping caused no movement in the scene.
+            // we return here to prevent rebuilding a bunch of brushes.
+            if (!didAnyPositionChange) return;
 
 			for (int brushIndex = 0; brushIndex < targetBrushBases.Length; brushIndex++) 
 			{


### PR DESCRIPTION
When you used the bounds tool or translate tool to move brushes around the Auto Rebuild function would invalidate brushes on every mouse pixel movement even when no brushes were actually modified due to grid snapping:

![before](https://user-images.githubusercontent.com/7905726/38635830-dfee359a-3dc6-11e8-90ae-07192ef5eb03.gif)

Now the brushes only rebuild when there was an actual change. This gives SabreCSG a couple milliseconds of time between snapped movements to rebuild the scene. As it won't be busy anymore the next time the brushes change it can immediately react instead of possibly still rebuilding unchanged brushes. Everything feels more responsive:

![after](https://user-images.githubusercontent.com/7905726/38635919-1f1e4606-3dc7-11e8-821e-785804f48342.gif)