### PR TITLE
Screen effect to remove flickering pixel artefacts. Please test this everyone!

### DIFF
--- a/Scripts/Effects/TJunctionEliminator.cs
+++ b/Scripts/Effects/TJunctionEliminator.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Sabresaurus.SabreCSG
+{
+    public class TJunctionEliminator : MonoBehaviour
+    {
+        private Material material;
+
+        // Use this for initialization
+        private void Start()
+        {
+            material = new Material(Shader.Find("SabreCSG/TJunctionEliminator"));
+        }
+
+        // Postprocess the image
+        private void OnRenderImage(RenderTexture source, RenderTexture destination)
+        {
+            //material.SetFloat("_bwBlend", intensity);
+            Graphics.Blit(source, destination, material);
+        }
+    }
+}

--- a/Scripts/Effects/TJunctionEliminator.cs.meta
+++ b/Scripts/Effects/TJunctionEliminator.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: aa58a307dbb6f124bb57bffc18cda0d7
+timeCreated: 1523816906
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Shaders/TJunctionEliminator.shader
+++ b/Shaders/TJunctionEliminator.shader
@@ -1,0 +1,126 @@
+﻿Shader "SabreCSG/TJunctionEliminator"
+{
+	Properties
+	{
+		_MainTex ("Texture", 2D) = "white" {}
+	}
+	SubShader
+	{
+		// No culling or depth
+		Cull Off ZWrite Off ZTest Always
+
+		Pass
+		{
+			CGPROGRAM
+			#pragma vertex vert
+			#pragma fragment frag
+			
+			#include "UnityCG.cginc"
+
+			sampler2D _CameraDepthTexture;
+			float4 _CameraDepthTexture_TexelSize;
+
+			struct appdata
+			{
+				float4 vertex : POSITION;
+				float2 uv : TEXCOORD0;
+			};
+
+			struct v2f
+			{
+				float2 uv : TEXCOORD0;
+				float4 vertex : SV_POSITION;
+			};
+
+			v2f vert (appdata v)
+			{
+				v2f o;
+				o.vertex = UnityObjectToClipPos(v.vertex);
+				o.uv = v.uv;
+				return o;
+			}
+			
+			sampler2D _MainTex;
+
+			int isShimmeringPixel(float2 uv : TEXCOORD) : COLOR
+			{
+				float xmin = _CameraDepthTexture_TexelSize.x;
+				float ymin = _CameraDepthTexture_TexelSize.y;
+				float xoff = uv.x / 1.0f;
+				float yoff = uv.y / 1.0f;
+	
+				float4 s01 = tex2D(_CameraDepthTexture, float2(xoff - xmin, yoff       ));
+				float4 s10 = tex2D(_CameraDepthTexture, float2(xoff       , yoff - ymin));
+				float4 s11 = tex2D(_CameraDepthTexture, float2(xoff       , yoff       ));
+				float4 s12 = tex2D(_CameraDepthTexture, float2(xoff       , yoff + ymin));
+				float4 s21 = tex2D(_CameraDepthTexture, float2(xoff + xmin, yoff       ));
+
+				float surrounding = (s01.r + s10.r + s12.r + s21.r) / 4.0f;
+
+				if (surrounding - s11.r > 0.00001f)
+					return 1;
+				return 0;
+			}
+
+			float4 sampleSurroundingPixels(float2 uv : TEXCOORD) : COLOR
+			{
+				float xmin = _CameraDepthTexture_TexelSize.x;
+				float ymin = _CameraDepthTexture_TexelSize.y;
+				float xoff = uv.x / 1.0f;
+				float yoff = uv.y / 1.0f;
+	
+				float4 s01 = tex2D(_MainTex, float2(xoff - xmin, yoff       ));
+				float4 s10 = tex2D(_MainTex, float2(xoff       , yoff - ymin));
+				float4 s12 = tex2D(_MainTex, float2(xoff       , yoff + ymin));
+				float4 s21 = tex2D(_MainTex, float2(xoff + xmin, yoff       ));
+	
+				return float4(
+					(s01.r + s10.r + s12.r + s21.r) / 4.0f,
+					(s01.g + s10.g + s12.g + s21.g) / 4.0f,
+					(s01.b + s10.b + s12.b + s21.b) / 4.0f,
+					1.0f
+				);
+			}
+
+			fixed4 frag (v2f i) : SV_Target
+			{
+				fixed4 col = tex2D(_MainTex, i.uv);
+
+				if (isShimmeringPixel(i.uv))
+				{
+					col = sampleSurroundingPixels(i.uv);
+					//col.r = 0.0f;
+					//col.g = 1.0f;
+					//col.b = 0.0f;
+				}
+				return col;
+			}
+
+			//float4 sampleArea(float2 uv : TEXCOORD) : COLOR
+			//{
+			//	float xmin = _CameraDepthTexture_TexelSize.x;
+			//	float ymin = _CameraDepthTexture_TexelSize.y;
+			//	float xoff = uv.x / 1.0f;
+			//	float yoff = uv.y / 1.0f;
+			//
+			//	float4 s00 = tex2D(_CameraDepthTexture, float2(xoff - xmin, yoff - ymin));
+			//	float4 s01 = tex2D(_CameraDepthTexture, float2(xoff - xmin, yoff       ));
+			//	float4 s02 = tex2D(_CameraDepthTexture, float2(xoff - xmin, yoff + ymin));
+			//	float4 s10 = tex2D(_CameraDepthTexture, float2(xoff       , yoff - ymin));
+			//	float4 s11 = tex2D(_CameraDepthTexture, float2(xoff       , yoff       ));
+			//	float4 s12 = tex2D(_CameraDepthTexture, float2(xoff       , yoff + ymin));
+			//	float4 s20 = tex2D(_CameraDepthTexture, float2(xoff + xmin, yoff - ymin));
+			//	float4 s21 = tex2D(_CameraDepthTexture, float2(xoff + xmin, yoff       ));
+			//	float4 s22 = tex2D(_CameraDepthTexture, float2(xoff + xmin, yoff + ymin));
+			//
+			//	return float4(
+			//		(s00.r + s01.r + s02.r + s10.r + s11.r + s12.r + s20.r + s21.r + s22.r) / 9.0f,
+			//		(s00.g + s01.g + s02.g + s10.g + s11.g + s12.g + s20.g + s21.g + s22.g) / 9.0f,
+			//		(s00.b + s01.b + s02.b + s10.b + s11.b + s12.b + s20.b + s21.b + s22.b) / 9.0f,
+			//		1.0f
+			//	);
+			//}
+			ENDCG
+		}
+	}
+}

--- a/Shaders/TJunctionEliminator.shader.meta
+++ b/Shaders/TJunctionEliminator.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 9d0bb50afc42a6f45ab5d0383f6b1558
+timeCreated: 1523816787
+licenseType: Free
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Post process screen effect to remove flickering pixel artefacts. An alternative solution to actually going in and fixing the mesh (it takes ages for the algorithm to complete at the moment).

Add the script to your camera object:

![image](https://user-images.githubusercontent.com/7905726/38783583-3d909216-4104-11e8-96d1-34746018900f.png)

You will immediately feel better:

![image](https://user-images.githubusercontent.com/7905726/38783649-68974fd0-4105-11e8-8790-855ab28fc3c1.png)

<hr>

On your Camera object you **MUST DISABLE MSAA** for this shader to work:

![image](https://user-images.githubusercontent.com/7905726/38783566-f8177c86-4103-11e8-83b2-a36e8c2ce0c9.png)

If you do need MSAA use an [Antialiasing screen effect](https://assetstore.unity.com/packages/essentials/legacy-image-effects-83913) below this script.

You can [download this SabreCSG version here](https://github.com/Henry00IS/SabreCSG/archive/TJunctionEliminator.zip). Please test it and let me know if it all works as it should.