### PR TITLE
Revert "2DSE extruding brush can be undone properly. Fixes #87."

### DIFF
--- a/Scripts/Brushes/CompoundBrushes/ShapeEditor/ShapeEditorBrush.cs
+++ b/Scripts/Brushes/CompoundBrushes/ShapeEditor/ShapeEditorBrush.cs
@@ -285,18 +285,6 @@ namespace Sabresaurus.SabreCSG.ShapeEditor
         }
 
         /// <summary>
-        /// Called when undo or redo is performed in the editor.
-        /// </summary>
-        public override void OnUndoRedoPerformed()
-        {
-            // reset our cached polygon data.
-            isDirty = true;
-            m_LastBuiltPolygons = null;
-            // the base method will invalidate this compound brush.
-            base.OnUndoRedoPerformed();
-        }
-
-        /// <summary>
         /// Gets the next segment.
         /// </summary>
         /// <param name="segment">The segment to find the next segment for.</param>
@@ -695,9 +683,6 @@ namespace Sabresaurus.SabreCSG.ShapeEditor
         /// <param name="project">The project to be copied into the brush.</param>
         public void CreatePolygon(Project project)
         {
-#if UNITY_EDITOR
-            UnityEditor.Undo.RecordObject(this, "Create Polygon");
-#endif
             // store a project copy inside of this brush.
             this.project = project.Clone();
             // store the extrude mode inside of this brush.
@@ -715,9 +700,6 @@ namespace Sabresaurus.SabreCSG.ShapeEditor
         /// <param name="project">The project to be copied into the brush.</param>
         public void RevolveShape(Project project)
         {
-#if UNITY_EDITOR
-            UnityEditor.Undo.RecordObject(this, "Revolve Shape");
-#endif
             // store a project copy inside of this brush.
             this.project = project.Clone();
             // store the extrude mode inside of this brush.
@@ -735,9 +717,6 @@ namespace Sabresaurus.SabreCSG.ShapeEditor
         /// <param name="project">The project to be copied into the brush.</param>
         public void ExtrudeShape(Project project)
         {
-#if UNITY_EDITOR
-            UnityEditor.Undo.RecordObject(this, "Extrude Shape");
-#endif
             // store a project copy inside of this brush.
             this.project = project.Clone();
             // store the extrude mode inside of this brush.
@@ -755,9 +734,6 @@ namespace Sabresaurus.SabreCSG.ShapeEditor
         /// <param name="project">The project to be copied into the brush.</param>
         public void ExtrudePoint(Project project)
         {
-#if UNITY_EDITOR
-            UnityEditor.Undo.RecordObject(this, "Extrude Point");
-#endif
             // store a project copy inside of this brush.
             this.project = project.Clone();
             // store the extrude mode inside of this brush.
@@ -776,9 +752,6 @@ namespace Sabresaurus.SabreCSG.ShapeEditor
         /// <param name="project">The project to be copied into the brush.</param>
         public void ExtrudeBevel(Project project)
         {
-#if UNITY_EDITOR
-            UnityEditor.Undo.RecordObject(this, "Extrude Bevel");
-#endif
             // if the depth and clip depth are identical, extrude a point instead.
             if (project.extrudeDepth.EqualsWithEpsilon(project.extrudeClipDepth))
             {


### PR DESCRIPTION
My partner managed to obliterate one my maps by accidentally opening the CSG Model and clicking around. He pressed CTRL+Z and because all brushes were selected the 2D Shape Editor brushes reset and lost all their texturing work (we use git so it's fine though 😋).

That's because I tried to implement undo functionality in 2DSE brushes but right now it's too dangerous to keep it like this. I don't know a good way to fix it so I will undo this commit until there is a good solution. I apologize, this could have happened with groups as well, clearly an oversight on my part.