### PR TITLE
Severe performance improvement for brush preview rendering. Fixes #111.

### DIFF
--- a/Scripts/Brushes/PrimitiveBrush.cs
+++ b/Scripts/Brushes/PrimitiveBrush.cs
@@ -674,17 +674,16 @@ namespace Sabresaurus.SabreCSG
 
             if (polygons != null)
             {
-                List<int> polygonIndices;
-                BrushFactory.GenerateMeshFromPolygons(polygons, ref renderMesh, out polygonIndices);
+                // generate a mesh preview for the transparent brushes.
+                // we also displace the triangles along the normals slightly so we can overlay built geometry
+                // with semi-transparent geometry and avoid depth fighting.
+                BrushFactory.GenerateMeshFromPolygonsFast(polygons, ref renderMesh, 0.001f);
             }
 
             if (mode == CSGMode.Subtract)
             {
                 MeshHelper.Invert(ref renderMesh);
             }
-            // Displace the triangles for display along the normals very slightly (this is so we can overlay built
-            // geometry with semi-transparent geometry and avoid depth fighting)
-            MeshHelper.Displace(ref renderMesh, 0.001f);
 
             meshFilter.sharedMesh = renderMesh;
 

--- a/Scripts/CSGModel.cs
+++ b/Scripts/CSGModel.cs
@@ -376,8 +376,7 @@ namespace Sabresaurus.SabreCSG
 					SabreCSGResources.GetExcludedMaterial().SetPass(0);
 
 					Mesh mesh = new Mesh();
-					List<int> indices = new List<int>();
-					BrushFactory.GenerateMeshFromPolygons(excluded.ToArray(), ref mesh, out indices);
+					BrushFactory.GenerateMeshFromPolygonsFast(excluded.ToArray(), ref mesh, 0.0f);
 
 					Graphics.DrawMeshNow(mesh, Vector3.zero, Quaternion.identity);
 


### PR DESCRIPTION
Issue #111 [Found a huge potential performance optimization](https://github.com/sabresaurus/SabreCSG/issues/111) explains in detail what the problem is.

Instead of creating proper indices on the CPU I now immediately push duplicate vertices to the GPU. I also replaced all of the C# lists with fixed-size arrays reducing the memory usage per call from 1.5 GiB or more to an insignificant amount that no longer freezes the editor.

Performance improvements when:
* Moving complex brushes around the scene.
* Disabling/Enabling brushes.
* Viewing excluded polygons.

Attempting to move a single extremely complex brush with 512 polygons, before:

![slow](https://user-images.githubusercontent.com/7905726/39956928-5b1876c8-55ea-11e8-82ce-e64b1d4710ca.gif)

Using this new pull request:

![fast](https://user-images.githubusercontent.com/7905726/39956930-68b0e6a8-55ea-11e8-977a-d27a924f1fb0.gif)

Attempting to view excluded polygons, before:

![excludedslow](https://user-images.githubusercontent.com/7905726/39956966-294fe5c6-55eb-11e8-954f-dbc7f52c2af4.gif)

Attempting to view excluded polygons, after:

![excludedfast](https://user-images.githubusercontent.com/7905726/39956969-333cdeea-55eb-11e8-8afd-8a5f26349217.gif)