### PR TITLE
VMF importer scale now matches the Unity metric system and SabreCSG grid.

### DIFF
--- a/Scripts/Importers/ValveMapFormat2006/VmfWorldConverter.cs
+++ b/Scripts/Importers/ValveMapFormat2006/VmfWorldConverter.cs
@@ -12,7 +12,7 @@ namespace Sabresaurus.SabreCSG.Importers.ValveMapFormat2006
     /// </summary>
     public static class VmfWorldConverter
     {
-        private const float inchesInMeters = 0.0254f;
+        private const float inchesInMeters = 0.03125f; // 1/32
 
         /// <summary>
         /// Imports the specified world into the SabreCSG model.


### PR DESCRIPTION
Some code I found used the real world equivalent of inches to meters which, while it may look correct on first glance, doesn't make any sense and it's definitely not the metric system. Using 1/32 (0.03125) yields results that look and feel a lot more accurate and match SabreCSG's grid 100%.

![Portal Test Chamber](https://user-images.githubusercontent.com/7905726/40327214-677d2008-5d42-11e8-94af-a9be0179e8f1.png)


At first I would bump my head into the platform. Now I look up at it (even though my player is larger than the portal one, oops) and it would partially obscure the Weighted Companion Cube that's usually on top of there just like I vaguely recall. Comparing my image to images from the game it seems perfect.

![Portal Game](https://user-images.githubusercontent.com/7905726/40327143-23ab88ba-5d42-11e8-91ab-1760c9c865d0.png)


Anyway I now declare this accurate.