### PR TITLE
Unreal Gold Scaling Fixes

### DIFF
--- a/Scripts/Importers/UnrealGold/T3dImporter.cs
+++ b/Scripts/Importers/UnrealGold/T3dImporter.cs
@@ -307,12 +307,16 @@ namespace Sabresaurus.SabreCSG.Importers.UnrealGold
                 if (rawvalue[1] == 'S' && rawvalue[2] != 'h')
                 {
                     // (Scale=(X=0.173205,Y=0.150000,Z=0.125000),SheerAxis=SHEER_ZX)
-                    string x = rawvalue.Replace("(Scale=", "x=").Replace(",SheerAxis=SHEER_ZX)", "");
+                    string x = rawvalue.Replace("(Scale=", "X=").Replace(",SheerAxis=SHEER_ZX)", "");
                     string k;
                     object v;
                     if (TryParseProperty(x, out k, out v))
                     {
-                        value = v; // vector.
+                        T3dVector3 vec = (T3dVector3)v;
+                        vec.X = vec.X == 0.0f ? 1.0f : vec.X;
+                        vec.Y = vec.Y == 0.0f ? 1.0f : vec.Y;
+                        vec.Z = vec.Z == 0.0f ? 1.0f : vec.Z;
+                        value = vec; // vector.
                         return true;
                     }
                 }

--- a/Scripts/Importers/UnrealGold/T3dMapConverter.cs
+++ b/Scripts/Importers/UnrealGold/T3dMapConverter.cs
@@ -48,7 +48,7 @@ namespace Sabresaurus.SabreCSG.Importers.UnrealGold
                         Vertex[] vertices = new Vertex[tpolygon.Vertices.Count];
                         for (int j = 0; j < tpolygon.Vertices.Count; j++)
                         {
-                            vertices[j] = new Vertex(ToVector3(tpolygon.Vertices[j]) / (float)scale, ToVector3(tpolygon.Normal), GenerateUV(tpolygon, j, material));
+                            vertices[j] = new Vertex(ToVector3(tpolygon.Vertices[j]).Multiply(ToVector3Raw(tactor.MainScale)).Multiply(ToVector3Raw(tactor.PostScale)) / (float)scale, ToVector3(tpolygon.Normal), GenerateUV(tpolygon, j, material));
                         }
 
                         // detect the polygon flags.
@@ -124,6 +124,16 @@ namespace Sabresaurus.SabreCSG.Importers.UnrealGold
         private static Vector3 ToVector3(T3dVector3 vector3)
         {
             return new Vector3(-vector3.X, vector3.Z, vector3.Y);
+        }
+
+        /// <summary>
+        /// Converts <see cref="T3dVector3"/> to <see cref="Vector3"/>.
+        /// </summary>
+        /// <param name="vector3">The <see cref="T3dVector3"/> to be converted.</param>
+        /// <returns>The <see cref="Vector3"/>.</returns>
+        private static Vector3 ToVector3Raw(T3dVector3 vector3)
+        {
+            return new Vector3(vector3.X, vector3.Z, vector3.Y);
         }
 
         private static float DotProduct(float ax, float ay, float az, float bx, float by, float bz)

--- a/Scripts/Importers/UnrealGold/T3dMapConverter.cs
+++ b/Scripts/Importers/UnrealGold/T3dMapConverter.cs
@@ -48,7 +48,15 @@ namespace Sabresaurus.SabreCSG.Importers.UnrealGold
                         Vertex[] vertices = new Vertex[tpolygon.Vertices.Count];
                         for (int j = 0; j < tpolygon.Vertices.Count; j++)
                         {
-                            vertices[j] = new Vertex(ToVector3(tpolygon.Vertices[j]).Multiply(ToVector3Raw(tactor.MainScale)).Multiply(ToVector3Raw(tactor.PostScale)) / (float)scale, ToVector3(tpolygon.Normal), GenerateUV(tpolygon, j, material));
+                            // main-scale
+                            // scale around pivot point.
+                            Vector3 vertexPosition = ToVector3(tpolygon.Vertices[j]);
+                            Vector3 pivot = ToVector3(tactor.PrePivot);
+                            Vector3 difference = vertexPosition - pivot;
+                            vertexPosition = difference.Multiply(ToVector3Raw(tactor.MainScale)) + pivot;
+
+                            // post-scale
+                            vertices[j] = new Vertex(vertexPosition.Multiply(ToVector3Raw(tactor.PostScale)) / (float)scale, ToVector3(tpolygon.Normal), GenerateUV(tpolygon, j, material));
                         }
 
                         // detect the polygon flags.
@@ -59,7 +67,7 @@ namespace Sabresaurus.SabreCSG.Importers.UnrealGold
                         polygons[i] = new Polygon(vertices, material, false, userExcludeFromFinal);
                     }
 
-                    // position and rotate the brushes.
+                    // position and rotate the brushes around their pivot point.
                     Transform transform = model.CreateCustomBrush(polygons).transform;
                     transform.position = (ToVector3(tactor.Location) / (float)scale) - (ToVector3(tactor.PrePivot) / (float)scale);
                     Vector3 axis;


### PR DESCRIPTION
According [to this forum thread](https://www.oldunreal.com/cgi-bin/yabb2/YaBB.pl?num=1527159655/0#4) the brush scaling was completely ignored by my importer. This has now been fixed. "MainScale" scales brushes around the pivot point and "PostScale" scales brushes linearly.