### PR TITLE
Screen.safeArea missing when using Unity 2017.2.0f3. Fixes #126.

### DIFF
--- a/Scripts/Brushes/CompoundBrushes/Editor/ShapeEditorWindow.cs
+++ b/Scripts/Brushes/CompoundBrushes/Editor/ShapeEditorWindow.cs
@@ -1078,7 +1078,7 @@ namespace Sabresaurus.SabreCSG.ShapeEditor
         private void OnHome()
         {
             // scroll to the center of the screen.
-#if UNITY_2017_2_OR_NEWER
+#if UNITY_2017_2_OR_NEWER && !UNITY_2017_2
             viewportScroll = new Vector2(Screen.safeArea.width / 2.0f / EditorGUIUtility.pixelsPerPoint, Screen.safeArea.height / 2.0f / EditorGUIUtility.pixelsPerPoint);
 #else
             viewportScroll = new Vector2(Screen.width / 2.0f, Screen.height / 2.0f);
@@ -1452,7 +1452,7 @@ namespace Sabresaurus.SabreCSG.ShapeEditor
 
         private Rect GetViewportRect()
         {
-#if UNITY_2017_2_OR_NEWER
+#if UNITY_2017_2_OR_NEWER && !UNITY_2017_2
             Rect viewportRect = Screen.safeArea;
 #else
             Rect viewportRect = new Rect(0, 0, Screen.width, Screen.height);
@@ -1584,7 +1584,7 @@ namespace Sabresaurus.SabreCSG.ShapeEditor
             Vector2 size = popup.GetWindowSize();
             try
             {
-#if UNITY_2017_2_OR_NEWER
+#if UNITY_2017_2_OR_NEWER && !UNITY_2017_2
                 PopupWindow.Show(new Rect((Screen.safeArea.width / 2.0f / EditorGUIUtility.pixelsPerPoint) - (size.x / 2.0f), (Screen.safeArea.height / 2.0f / EditorGUIUtility.pixelsPerPoint) - (size.y / 2.0f), 0, 0), popup);
 #else
                 PopupWindow.Show(new Rect((Screen.width / 2.0f) - (size.x / 2.0f), (Screen.height / 2.0f) - (size.y / 2.0f), 0, 0), popup);


### PR DESCRIPTION
Added the required fallback code for 2017.2.0f3.