### PR TITLE
Subtractive brush stability update against corruptions

### DIFF
--- a/Scripts/Extensions/MathHelper.cs
+++ b/Scripts/Extensions/MathHelper.cs
@@ -312,7 +312,7 @@ namespace Sabresaurus.SabreCSG
         public static bool PlaneEqualsLooserWithFlip(Plane plane1, Plane plane2)
         {
             if (
-                Mathf.Abs(plane1.distance - plane2.distance) <= 0.02f
+                Mathf.Abs(plane1.distance - plane2.distance) <= 0.08f
                 && Mathf.Abs(plane1.normal.x - plane2.normal.x) < 0.006f
                 && Mathf.Abs(plane1.normal.y - plane2.normal.y) < 0.006f
                 && Mathf.Abs(plane1.normal.z - plane2.normal.z) < 0.006f)
@@ -320,7 +320,7 @@ namespace Sabresaurus.SabreCSG
                 return true;
             }
             else if (
-                Mathf.Abs(-plane1.distance - plane2.distance) <= 0.02f
+                Mathf.Abs(-plane1.distance - plane2.distance) <= 0.08f
                 && Mathf.Abs(-plane1.normal.x - plane2.normal.x) < 0.006f
                 && Mathf.Abs(-plane1.normal.y - plane2.normal.y) < 0.006f
                 && Mathf.Abs(-plane1.normal.z - plane2.normal.z) < 0.006f)

--- a/Scripts/Extensions/MathHelper.cs
+++ b/Scripts/Extensions/MathHelper.cs
@@ -312,18 +312,18 @@ namespace Sabresaurus.SabreCSG
         public static bool PlaneEqualsLooserWithFlip(Plane plane1, Plane plane2)
         {
             if (
-                Mathf.Abs(plane1.distance - plane2.distance) < EPSILON_LOWER_3
-                && Mathf.Abs(plane1.normal.x - plane2.normal.x) < EPSILON_LOWER_2
-                && Mathf.Abs(plane1.normal.y - plane2.normal.y) < EPSILON_LOWER_2
-                && Mathf.Abs(plane1.normal.z - plane2.normal.z) < EPSILON_LOWER_2)
+                Mathf.Abs(plane1.distance - plane2.distance) <= 0.02f
+                && Mathf.Abs(plane1.normal.x - plane2.normal.x) < EPSILON_LOWER_3
+                && Mathf.Abs(plane1.normal.y - plane2.normal.y) < EPSILON_LOWER_3
+                && Mathf.Abs(plane1.normal.z - plane2.normal.z) < EPSILON_LOWER_3)
             {
                 return true;
             }
             else if (
-                Mathf.Abs(-plane1.distance - plane2.distance) < EPSILON_LOWER_3
-                && Mathf.Abs(-plane1.normal.x - plane2.normal.x) < EPSILON_LOWER_2
-                && Mathf.Abs(-plane1.normal.y - plane2.normal.y) < EPSILON_LOWER_2
-                && Mathf.Abs(-plane1.normal.z - plane2.normal.z) < EPSILON_LOWER_2)
+                Mathf.Abs(-plane1.distance - plane2.distance) <= 0.02f
+                && Mathf.Abs(-plane1.normal.x - plane2.normal.x) < EPSILON_LOWER_3
+                && Mathf.Abs(-plane1.normal.y - plane2.normal.y) < EPSILON_LOWER_3
+                && Mathf.Abs(-plane1.normal.z - plane2.normal.z) < EPSILON_LOWER_3)
             {
                 return true;
             }

--- a/Scripts/Extensions/MathHelper.cs
+++ b/Scripts/Extensions/MathHelper.cs
@@ -313,17 +313,17 @@ namespace Sabresaurus.SabreCSG
         {
             if (
                 Mathf.Abs(plane1.distance - plane2.distance) <= 0.02f
-                && Mathf.Abs(plane1.normal.x - plane2.normal.x) < EPSILON_LOWER_3
-                && Mathf.Abs(plane1.normal.y - plane2.normal.y) < EPSILON_LOWER_3
-                && Mathf.Abs(plane1.normal.z - plane2.normal.z) < EPSILON_LOWER_3)
+                && Mathf.Abs(plane1.normal.x - plane2.normal.x) < 0.006f
+                && Mathf.Abs(plane1.normal.y - plane2.normal.y) < 0.006f
+                && Mathf.Abs(plane1.normal.z - plane2.normal.z) < 0.006f)
             {
                 return true;
             }
             else if (
                 Mathf.Abs(-plane1.distance - plane2.distance) <= 0.02f
-                && Mathf.Abs(-plane1.normal.x - plane2.normal.x) < EPSILON_LOWER_3
-                && Mathf.Abs(-plane1.normal.y - plane2.normal.y) < EPSILON_LOWER_3
-                && Mathf.Abs(-plane1.normal.z - plane2.normal.z) < EPSILON_LOWER_3)
+                && Mathf.Abs(-plane1.normal.x - plane2.normal.x) < 0.006f
+                && Mathf.Abs(-plane1.normal.y - plane2.normal.y) < 0.006f
+                && Mathf.Abs(-plane1.normal.z - plane2.normal.z) < 0.006f)
             {
                 return true;
             }


### PR DESCRIPTION
MathHelper.cs PlaneEqualsLooserWithFlip is now even looser (less precise, allowing for more floating point errors and causing less false positives). Feedback please!

![Before and after the fix](https://user-images.githubusercontent.com/7905726/40984966-5b17750a-68e3-11e8-8dc8-527073d61ade.png)

This may just deal with #8, one of the oldest open issues.