### PR TITLE
2DSE: Fixed inverted extrude direction on flipped projects.

### DIFF
--- a/Scripts/Brushes/CompoundBrushes/Editor/ShapeEditorWindow.cs
+++ b/Scripts/Brushes/CompoundBrushes/Editor/ShapeEditorWindow.cs
@@ -1156,9 +1156,10 @@ namespace Sabresaurus.SabreCSG.ShapeEditor
         {
             foreach (Segment segment in selectedSegments.ToArray()) // use .ToArray() to iterate a clone.
             {
+                bool inverted = project.flipHorizontally ^ project.flipVertically;
                 Segment next = GetNextSegment(segment);
                 // calculate extrude direction.
-                Vector2Int pos1 = next.position - segment.position;
+                Vector2Int pos1 = (inverted ? segment.position - next.position : next.position - segment.position);
                 Vector2 dir = new Vector2(pos1.y, -pos1.x).normalized * 2.0f;
                 // insert new segments at an extruded distance.
                 Shape parent = GetShapeOfSegment(segment);


### PR DESCRIPTION
When you flipped your project horizontally or vertically the extrude segment operation would also be inverted leading to some awkward workflow issues. This is the first time that I ever used the XOR operator in C# (it's ^).