### PR TITLE
Fixed HollowBoxBrush compilation errors.

### DIFF
--- a/Scripts/Brushes/CompoundBrushes/Editor/HollowBoxBrushInspector.cs.meta
+++ b/Scripts/Brushes/CompoundBrushes/Editor/HollowBoxBrushInspector.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 9a76fa0614387084cb85b598c0744270
+timeCreated: 1528366657
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Brushes/CompoundBrushes/HollowBoxBrush.cs
+++ b/Scripts/Brushes/CompoundBrushes/HollowBoxBrush.cs
@@ -1,111 +1,119 @@
-﻿namespace Sabresaurus.SabreCSG
+﻿#if UNITY_EDITOR || RUNTIME_CSG
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Sabresaurus.SabreCSG
 {
-	using UnityEngine;
+    [ExecuteInEditMode]
+    public class HollowBoxBrush : CompoundBrush
+    {
+        /// <summary>
+        /// Gets or sets the thickness of the walls.
+        /// </summary>
+        /// <value>The thickness of the walls.</value>
+        public float WallThickness
+        {
+            get
+            {
+                return wallThickness;
+            }
+            set
+            {
+                wallThickness = value;
+            }
+        }
 
-	public class HollowBoxBrush : CompoundBrush
-	{
-		/// <summary>
-		/// Gets or sets the thickness of the walls.
-		/// </summary>
-		/// <value>The thickness of the walls.</value>
-		public float WallThickness
-		{
-			get
-			{
-				return wallThickness;
-			}
-			set
-			{
-				wallThickness = value;
-			}
-		}
+        /// <summary>
+        /// Gets the beautiful name of the brush used in auto-generation of the hierarchy name.
+        /// </summary>
+        /// <value>The beautiful name of the brush.</value>
+        public override string BeautifulBrushName
+        {
+            get
+            {
+                return "Hollow Box Brush";
+            }
+        }
 
-		/// <summary>
-		/// Gets the beautiful name of the brush used in auto-generation of the hierarchy name.
-		/// </summary>
-		/// <value>The beautiful name of the brush.</value>
-		public override string BeautifulBrushName
-		{
-			get
-			{
-				return "Hollow Box Brush";
-			}
-		}
+        public override int BrushCount
+        {
+            get
+            {
+                // If the brush is too small for walls, just default to a single brush.
+                return (IsBrushXYZTooSmall) ? 2 : 1;
+            }
+        }
 
-		public override int BrushCount
-		{
-			get
-			{
-				// If the brush is too small for walls, just default to a single brush.
-				return ( IsBrushXYZTooSmall ) ? 2 : 1;
-			}
-		}
+        /// <summary>
+        /// Is the size of the bounds X, Y, and Z above the minimum size?
+        /// </summary>
+        /// <returns></returns>
+        public bool IsBrushXYZTooSmall
+        {
+            get
+            {
+                return localBounds.size.x > wallThickness * 2.0f && localBounds.size.z > wallThickness * 2.0f && localBounds.size.y > wallThickness * 2;
+            }
+        }
 
-		/// <summary>
-		/// Is the size of the bounds X, Y, and Z above the minimum size?
-		/// </summary>
-		/// <returns></returns>
-		public bool IsBrushXYZTooSmall
-		{
-			get
-			{
-				return localBounds.size.x > wallThickness * 2.0f && localBounds.size.z > wallThickness * 2.0f && localBounds.size.y > wallThickness * 2;
-			}
-		}
+        /// <summary>
+        /// The thickness of the walls.
+        /// </summary>
+        [SerializeField]
+        private float wallThickness = 0.25f;
 
-		/// <summary>
-		/// The thickness of the walls.
-		/// </summary>
-		[SerializeField]
-		private float wallThickness = 0.25f;
+        public override void UpdateVisibility()
+        {
+        }
 
-		public override void UpdateVisibility()
-		{
-		}
+        public override void Invalidate(bool polygonsChanged)
+        {
+            base.Invalidate(polygonsChanged);
 
-		public override void Invalidate( bool polygonsChanged )
-		{
-			base.Invalidate( polygonsChanged );
+            for (int i = 0; i < BrushCount; i++)
+            {
+                generatedBrushes[i].Mode = this.Mode;
+                generatedBrushes[i].IsNoCSG = this.IsNoCSG;
+                generatedBrushes[i].IsVisible = this.IsVisible;
+                generatedBrushes[i].HasCollision = this.HasCollision;
+            }
 
-			for( int i = 0; i < BrushCount; i++ )
-			{
-				generatedBrushes[i].Mode = this.Mode;
-				generatedBrushes[i].IsNoCSG = this.IsNoCSG;
-				generatedBrushes[i].IsVisible = this.IsVisible;
-				generatedBrushes[i].HasCollision = this.HasCollision;
-			}
+            if (IsBrushXYZTooSmall)
+            {
+                generatedBrushes[0].Mode = CSGMode.Add;
+                BrushUtility.Resize(generatedBrushes[0], localBounds.size);
 
-			if( IsBrushXYZTooSmall )
-			{
-				generatedBrushes[0].Mode = CSGMode.Add;
-				BrushUtility.Resize( generatedBrushes[0], localBounds.size );
+                generatedBrushes[1].Mode = CSGMode.Subtract;
+                BrushUtility.Resize(generatedBrushes[1], localBounds.size - new Vector3(wallThickness * 2, wallThickness * 2, wallThickness * 2));
 
-				generatedBrushes[1].Mode = CSGMode.Subtract;
-				BrushUtility.Resize( generatedBrushes[1], localBounds.size - new Vector3( wallThickness * 2, wallThickness * 2, wallThickness * 2 ) );
+                for (int i = 0; i < BrushCount; i++)
+                {
+                    generatedBrushes[i].SetPolygons(GeneratePolys(i));
+                    generatedBrushes[i].Invalidate(true);
+                }
+            }
+            else
+            {
+                BrushUtility.Resize(generatedBrushes[0], localBounds.size);
+            }
+        }
 
-				for( int i = 0; i < BrushCount; i++ )
-				{
-					generatedBrushes[i].SetPolygons( GeneratePolys( i ) );
-					generatedBrushes[i].Invalidate( true );
-				}
-			}
-			else
-			{
-				BrushUtility.Resize( generatedBrushes[0], localBounds.size );
-			}
-		}
+        private Polygon[] GeneratePolys(int index)
+        {
+            Polygon[] output = generatedBrushes[index].GetPolygons();
 
-		private Polygon[] GeneratePolys( int index )
-		{
-			Polygon[] output = generatedBrushes[index].GetPolygons();
+            for (int i = 0; i < 6; i++)
+            {
+                output[i].ResetVertexNormals();
+                output[i].GenerateUvCoordinates();
+            }
 
-			for( int i = 0; i < 6; i++ )
-			{
-				output[i].ResetVertexNormals();
-				output[i].GenerateUvCoordinates();
-			}
-
-			return output;
-		}
-	}
+            return output;
+        }
+    }
 }
+
+#endif

--- a/Scripts/Brushes/CompoundBrushes/HollowBoxBrush.cs.meta
+++ b/Scripts/Brushes/CompoundBrushes/HollowBoxBrush.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: eed65674ef786f142a6e53243f320513
+timeCreated: 1528366664
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
@Kerfuffles You wrote a `using` inside of a namespace causing it to find the wrong classes in other projects and forgot the important `#if` pre-processor statements and `[ExecuteInEditMode]`.