### PR TITLE
Optimize Geometry has been demoted and is now off by default.

### DIFF
--- a/Scripts/Core/CSGBuildSettings.cs
+++ b/Scripts/Core/CSGBuildSettings.cs
@@ -15,7 +15,7 @@ namespace Sabresaurus.SabreCSG
         // Also calculate tangents (needed for Unity's built in bump mapping)
         public bool GenerateTangents = true;
 
-        public bool OptimizeGeometry = true;
+        public bool OptimizeGeometry = false;
 
         public bool SaveMeshesAsAssets = false;
 


### PR DESCRIPTION
Sadly due to the current bugs in the algorithm that like to cover subtractive holes it will now be off by default. #103