### PR TITLE
Fixed HollowBoxBrush inspector compilation errors.

### DIFF
--- a/Scripts/Brushes/CompoundBrushes/Editor/HollowBoxBrushInspector.cs
+++ b/Scripts/Brushes/CompoundBrushes/Editor/HollowBoxBrushInspector.cs
@@ -1,44 +1,47 @@
-﻿namespace Sabresaurus.SabreCSG
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+namespace Sabresaurus.SabreCSG
 {
-	using UnityEditor;
-	using UnityEngine;
+    [CanEditMultipleObjects]
+    [CustomEditor(typeof(HollowBoxBrush), true)]
+    public class HollowBoxBrushInspector : CompoundBrushInspector
+    {
+        SerializedProperty wallThicknessProp;
 
-	[CanEditMultipleObjects]
-	[CustomEditor( typeof( HollowBoxBrush ), true )]
-	public class HollowBoxBrushInspector : CompoundBrushInspector
-	{
-		private SerializedProperty wallThicknessProp;
+        public override void DoInspectorGUI()
+        {
+            using (new NamedVerticalScope("Hollow Box"))
+            {
+                EditorGUI.BeginChangeCheck();
+                EditorGUILayout.PropertyField(wallThicknessProp);
 
-		public override void DoInspectorGUI()
-		{
-			using( new NamedVerticalScope( "Hollow Box" ) )
-			{
-				EditorGUI.BeginChangeCheck();
-				EditorGUILayout.PropertyField( wallThicknessProp );
+                if (EditorGUI.EndChangeCheck())
+                {
+                    ApplyAndInvalidate();
+                }
 
-				if( EditorGUI.EndChangeCheck() )
-				{
-					ApplyAndInvalidate();
-				}
+                EditorGUILayout.Space();
+            }
 
-				EditorGUILayout.Space();
-			}
+            base.DoInspectorGUI();
+        }
 
-			base.DoInspectorGUI();
-		}
+        protected override void OnEnable()
+        {
+            base.OnEnable();
 
-		protected override void OnEnable()
-		{
-			base.OnEnable();
+            // Setup the SerializedProperties.
+            wallThicknessProp = serializedObject.FindProperty("wallThickness");
+        }
 
-			// Setup the SerializedProperties.
-			wallThicknessProp = serializedObject.FindProperty( "wallThickness" );
-		}
-
-		private void ApplyAndInvalidate()
-		{
-			serializedObject.ApplyModifiedProperties();
-			System.Array.ForEach( BrushTargets, item => item.Invalidate( true ) );
-		}
-	}
+        private void ApplyAndInvalidate()
+        {
+            serializedObject.ApplyModifiedProperties();
+            System.Array.ForEach(BrushTargets, item => item.Invalidate(true));
+        }
+    }
 }


### PR DESCRIPTION
Found even more instances of usings inside of a namespace in the inspector of hollow box brushes. I'm sorry, I should have read the code more thoroughly before merging it.