### PR TITLE
Fixed missing material assignments in the VMF importer

### DIFF
--- a/Scripts/Importers/ValveMapFormat2006/VmfWorldConverter.cs
+++ b/Scripts/Importers/ValveMapFormat2006/VmfWorldConverter.cs
@@ -59,7 +59,7 @@ namespace Sabresaurus.SabreCSG.Importers.ValveMapFormat2006
 
                         // find the polygons associated with the clipping plane.
                         // the normal is unique and can never occur twice as that wouldn't allow the solid to be convex.
-                        var polygons = pr.GetPolygons().Where(p => p.Plane.normal == clip.normal);
+                        var polygons = pr.GetPolygons().Where(p => p.Plane.normal.EqualsWithEpsilonLower3(clip.normal));
                         foreach (var polygon in polygons)
                         {
                             // detect excluded polygons.
@@ -157,7 +157,7 @@ namespace Sabresaurus.SabreCSG.Importers.ValveMapFormat2006
 
                             // find the polygons associated with the clipping plane.
                             // the normal is unique and can never occur twice as that wouldn't allow the solid to be convex.
-                            var polygons = pr.GetPolygons().Where(p => p.Plane.normal == clip.normal);
+                            var polygons = pr.GetPolygons().Where(p => p.Plane.normal.EqualsWithEpsilonLower3(clip.normal));
                             foreach (var polygon in polygons)
                             {
                                 // detect excluded polygons.


### PR DESCRIPTION
Thanks to Baxayaun and the recent Quake 1 importer I fixed a floating point precision bug that caused some materials to not be applied to polygons.

Before:

![before](https://user-images.githubusercontent.com/7905726/45753719-f4ad4300-bc19-11e8-999a-d0cd28343792.png)

After:

![after](https://user-images.githubusercontent.com/7905726/45753776-19a1b600-bc1a-11e8-806b-ff0ab48dbae3.png)