### PR TITLE
Slight performance increase switching from Mesh.colors to Mesh.colors32.

### DIFF
--- a/Scripts/Core/BuildEngine/MeshGroupManager.cs
+++ b/Scripts/Core/BuildEngine/MeshGroupManager.cs
@@ -92,7 +92,7 @@ namespace Sabresaurus.SabreCSG
                 List<Vector3> positionsList = new List<Vector3>();
                 List<Vector3> normalsList = new List<Vector3>();
                 List<Vector2> uvList = new List<Vector2>();
-                List<Color> colorsList = new List<Color>();
+                List<Color32> colorsList = new List<Color32>();
                 List<int> trianglesList = new List<int>();
 
                 for (int i = 0; i < row.Value.Count; i++)
@@ -139,14 +139,14 @@ namespace Sabresaurus.SabreCSG
                         List<Vector3> positionsList,
                         List<Vector3> normalsList,
                         List<Vector2> uvList,
-                        List<Color> colorsList,
+                        List<Color32> colorsList,
                         List<int> trianglesList,
                         MaterialMeshDictionary materialMeshDictionary)
         {
             Vector3[] positionsArray = new Vector3[positionsList.Count];
             Vector3[] normalsArray = new Vector3[normalsList.Count];
             Vector2[] uvArray = new Vector2[uvList.Count];
-            Color[] colorsArray = new Color[colorsList.Count];
+            Color32[] colorsArray = new Color32[colorsList.Count];
             int[] trianglesArray = new int[trianglesList.Count];
 
             positionsList.CopyTo(positionsArray);
@@ -158,7 +158,7 @@ namespace Sabresaurus.SabreCSG
             mesh.vertices = positionsArray;
             mesh.normals = normalsArray;
             mesh.uv = uvArray;
-            mesh.colors = colorsArray;
+            mesh.colors32 = colorsArray;
 
             if (meshGroupHolder.position != Vector3.zero
                 || meshGroupHolder.rotation != Quaternion.identity
@@ -343,7 +343,7 @@ namespace Sabresaurus.SabreCSG
                 Vector3[] newPositions;
                 Vector3[] newNormals;
                 Vector2[] newUV;
-                Color[] newColors;
+                Color32[] newColors;
                 int[] newTriangles;
 
                 List<Polygon> polygons = row.Value;
@@ -354,7 +354,7 @@ namespace Sabresaurus.SabreCSG
             }
         }
 
-        internal static void TriangulatePolygons(bool individualVertices, List<Polygon> polygons, out int[] triangesToAppend, out Vector3[] positions, out Vector3[] normals, out Vector2[] uv, out Color[] colors)
+        internal static void TriangulatePolygons(bool individualVertices, List<Polygon> polygons, out int[] triangesToAppend, out Vector3[] positions, out Vector3[] normals, out Vector2[] uv, out Color32[] colors)
         {
             if (individualVertices)
             {
@@ -368,7 +368,7 @@ namespace Sabresaurus.SabreCSG
                 positions = new Vector3[totalVertexCount];
                 normals = new Vector3[totalVertexCount];
                 uv = new Vector2[totalVertexCount];
-                colors = new Color[totalVertexCount];
+                colors = new Color32[totalVertexCount];
 
                 triangesToAppend = new int[totalTriangleCount * 3];
 
@@ -430,7 +430,7 @@ namespace Sabresaurus.SabreCSG
                 positions = new Vector3[totalVertexCount];
                 normals = new Vector3[totalVertexCount];
                 uv = new Vector2[totalVertexCount];
-                colors = new Color[totalVertexCount];
+                colors = new Color32[totalVertexCount];
 
                 triangesToAppend = new int[totalTriangleCount * 3];
 

--- a/Scripts/Core/PolygonEntry.cs
+++ b/Scripts/Core/PolygonEntry.cs
@@ -18,7 +18,7 @@ namespace Sabresaurus.SabreCSG
 		public Vector2[] UV;
 
 		[SerializeField]
-		public Color[] Colors;
+		public Color32[] Colors;
 
 		[SerializeField]
 		public int[] Triangles;
@@ -42,7 +42,7 @@ namespace Sabresaurus.SabreCSG
 		public PolygonEntry (Vector3[] positions, 
 			Vector3[] normals, 
 			Vector2[] uv, 
-			Color[] colors,
+			Color32[] colors,
 			int[] triangles, 
 			Material material,
 			bool excludeFromBuild

--- a/Scripts/Core/PolygonFactory.cs
+++ b/Scripts/Core/PolygonFactory.cs
@@ -892,7 +892,7 @@ namespace Sabresaurus.SabreCSG
 			List<Vector3> vertices = new List<Vector3>();
 			List<Vector3> normals = new List<Vector3>();
 			List<Vector2> uvs = new List<Vector2>();
-			List<Color> colors = new List<Color>();
+			List<Color32> colors = new List<Color32>();
 			List<int> triangles = new List<int>();
 
 			// Set up an indexer that tracks unique vertices, so that we reuse vertex data appropiately
@@ -935,7 +935,7 @@ namespace Sabresaurus.SabreCSG
 			// Set the mesh buffers
 			mesh.vertices = vertices.ToArray();
 			mesh.normals = normals.ToArray();
-			mesh.colors = colors.ToArray();
+			mesh.colors32 = colors.ToArray();
 			mesh.uv = uvs.ToArray();
 			mesh.triangles = triangles.ToArray();
 		}

--- a/Scripts/Geometry/BrushFactory.cs
+++ b/Scripts/Geometry/BrushFactory.cs
@@ -764,7 +764,7 @@ namespace Sabresaurus.SabreCSG
             List<Vector3> vertices = new List<Vector3>();
             List<Vector3> normals = new List<Vector3>();
             List<Vector2> uvs = new List<Vector2>();
-            List<Color> colors = new List<Color>();
+            List<Color32> colors = new List<Color32>();
             List<int> triangles = new List<int>();
 
             // Maps triangle index (input) to polygon index (output). i.e. int polyIndex = polygonIndices[triIndex];
@@ -813,7 +813,7 @@ namespace Sabresaurus.SabreCSG
             // Set the mesh buffers
             mesh.vertices = vertices.ToArray();
             mesh.normals = normals.ToArray();
-            mesh.colors = colors.ToArray();
+            mesh.colors32 = colors.ToArray();
             mesh.uv = uvs.ToArray();
             mesh.triangles = triangles.ToArray();
         }

--- a/Scripts/Tools/SurfaceEditor.cs
+++ b/Scripts/Tools/SurfaceEditor.cs
@@ -2690,7 +2690,7 @@ namespace Sabresaurus.SabreCSG
                 Vector3[] destVertices = newMesh.vertices;
                 Vector2[] destUV = newMesh.uv;
                 Vector3[] destNormals = newMesh.normals;
-                Color[] destColors = newMesh.colors;
+                Color32[] destColors = newMesh.colors32;
 
                 int destVertexCount = destVertices.Length;
                 int destTriangleCount = destTriangles.Length;
@@ -2719,7 +2719,7 @@ namespace Sabresaurus.SabreCSG
                 newMesh.uv = destUV;
                 newMesh.normals = destNormals;
                 newMesh.triangles = destTriangles;
-                newMesh.colors = destColors;
+                newMesh.colors32 = destColors;
 
                 // If the mesh already has tangents
                 if (csgModel.LastBuildHadTangents)
@@ -2798,7 +2798,7 @@ namespace Sabresaurus.SabreCSG
             Vector3[] sourceVertices = originalMesh.vertices;
             Vector2[] sourceUV = originalMesh.uv;
             Vector2[] sourceUV2 = originalMesh.uv2;
-            Color[] sourceColors = originalMesh.colors;
+            Color32[] sourceColors = originalMesh.colors32;
             Vector3[] sourceNormals = originalMesh.normals;
             Vector4[] sourceTangents = originalMesh.tangents;
 
@@ -2810,7 +2810,7 @@ namespace Sabresaurus.SabreCSG
             Vector3[] destVertices = newMesh.vertices;
             Vector2[] destUV = newMesh.uv;
             Vector2[] destUV2 = newMesh.uv2;
-            Color[] destColors = newMesh.colors;
+            Color32[] destColors = newMesh.colors32;
             Vector3[] destNormals = newMesh.normals;
             Vector4[] destTangents = newMesh.tangents;
 
@@ -2873,7 +2873,7 @@ namespace Sabresaurus.SabreCSG
             newMesh.vertices = destVertices;
             newMesh.uv = destUV;
             newMesh.uv2 = destUV2;
-            newMesh.colors = destColors;
+            newMesh.colors32 = destColors;
             newMesh.normals = destNormals;
             newMesh.tangents = destTangents;
             newMesh.triangles = destTriangles;
@@ -2916,8 +2916,8 @@ namespace Sabresaurus.SabreCSG
                     {
                         Undo.RecordObject(entry.BuiltMesh, "Change Vertex Color");
 
-                        Color[] meshColors = entry.BuiltMesh.colors;
-                        Color[] colors = entry.Colors;
+                        Color32[] meshColors = entry.BuiltMesh.colors32;
+                        Color32[] colors = entry.Colors;
 
                         for (int vertexIndex = 0; vertexIndex < entry.Positions.Length; vertexIndex++)
                         {
@@ -2925,7 +2925,7 @@ namespace Sabresaurus.SabreCSG
                             meshColors[entry.BuiltVertexOffset + vertexIndex] = color;
                         }
                         entry.Colors = colors;
-                        entry.BuiltMesh.colors = meshColors;
+                        entry.BuiltMesh.colors32 = meshColors;
 
                         EditorHelper.SetDirty(entry.BuiltMesh);
                     }


### PR DESCRIPTION
There is a slight performance increase in some crucial places like building the visual mesh. The surface editor color picker is more responsive. `Colors32` prevents Unity having to convert `Colors` into a usable format. The [official documentation](https://docs.unity3d.com/ScriptReference/Mesh-colors32.html) confirms that it's better for performance.

Luckily the serialization doesn't care about the conversion between them and works.