### PR TITLE
Added SABRE_CSG_DEBUG mode to prevent performance regressions.

### DIFF
--- a/Scripts/Core/CSG/Edge.cs
+++ b/Scripts/Core/CSG/Edge.cs
@@ -72,9 +72,10 @@ namespace Sabresaurus.SabreCSG
         /// </exception>
         public Edge(Vertex vertex1, Vertex vertex2)
         {
+#if SABRE_CSG_DEBUG
             if (vertex1 == null) throw new ArgumentNullException("vertex1");
             if (vertex2 == null) throw new ArgumentNullException("vertex2");
-
+#endif
             this.vertex1 = vertex1;
             this.vertex2 = vertex2;
         }
@@ -93,8 +94,9 @@ namespace Sabresaurus.SabreCSG
         /// </exception>
         public bool Matches(Edge other)
         {
+#if SABRE_CSG_DEBUG
             if (other == null) throw new ArgumentNullException("other");
-
+#endif
             // check whether we approximately match the other edge:
             if (vertex1.Position.EqualsWithEpsilon(other.vertex1.Position)
                 && vertex2.Position.EqualsWithEpsilon(other.Vertex2.Position))
@@ -121,8 +123,9 @@ namespace Sabresaurus.SabreCSG
         /// </exception>
         public bool Parallel(Edge other)
         {
+#if SABRE_CSG_DEBUG
             if (other == null) throw new ArgumentNullException("other");
-
+#endif
             Vector3 direction1 = vertex2.Position - vertex1.Position;
             Vector3 direction2 = other.Vertex2.Position - other.Vertex1.Position;
 
@@ -145,8 +148,9 @@ namespace Sabresaurus.SabreCSG
         /// </exception>
         public bool Intersects(Edge other)
         {
+#if SABRE_CSG_DEBUG
             if (other == null) throw new ArgumentNullException("other");
-
+#endif
             // early out: if the edges aren't parallel to each other, they can't be collinear.
             if (!Parallel(other))
                 return false;
@@ -208,8 +212,9 @@ namespace Sabresaurus.SabreCSG
         /// </exception>
         public bool Collinear(Edge other)
         {
+#if SABRE_CSG_DEBUG
             if (other == null) throw new ArgumentNullException("other");
-
+#endif
             return EdgeUtility.EdgeMatches(this, other);
         }
 

--- a/Scripts/Core/CSG/Vertex.cs
+++ b/Scripts/Core/CSG/Vertex.cs
@@ -96,9 +96,10 @@ namespace Sabresaurus.SabreCSG
         /// </exception>
         public static Vertex Lerp(Vertex a, Vertex b, float t)
         {
+#if SABRE_CSG_DEBUG
             if (a == null) throw new ArgumentNullException("a");
             if (b == null) throw new ArgumentNullException("b");
-
+#endif
             return new Vertex()
             {
                 Position = Vector3.Lerp(a.Position, b.Position, t),

--- a/Scripts/UI/SabreCSGPreferences.cs
+++ b/Scripts/UI/SabreCSGPreferences.cs
@@ -12,7 +12,8 @@ namespace Sabresaurus.SabreCSG
     public class SabreCSGPreferences : EditorWindow
     {
         private const string RUNTIME_CSG_DEFINE = "RUNTIME_CSG";
-        private static readonly Vector2 WINDOW_SIZE = new Vector2(370, 360);
+        private const string SABRE_CSG_DEBUG_DEFINE = "SABRE_CSG_DEBUG";
+        private static readonly Vector2 WINDOW_SIZE = new Vector2(370, 400);
 
         //private static Event cachedEvent;
 
@@ -145,6 +146,34 @@ namespace Sabresaurus.SabreCSG
                     if (!definesSplit.Contains(RUNTIME_CSG_DEFINE))
                     {
                         definesSplit.Add(RUNTIME_CSG_DEFINE);
+                    }
+                    defines = string.Join(";", definesSplit.ToArray());
+                    PlayerSettings.SetScriptingDefineSymbolsForGroup(buildTargetGroup, defines);
+                }
+            }
+
+            GUILayout.Space(20);
+            GUILayout.Label("Debug mode executes additional code for verbose error checking. Used by SabreCSG developers.", style);
+            buildTargetGroup = EditorUserBuildSettings.selectedBuildTargetGroup;
+            defines = PlayerSettings.GetScriptingDefineSymbolsForGroup(buildTargetGroup);
+            definesSplit = defines.Split(';').ToList();
+            enabled = definesSplit.Contains(SABRE_CSG_DEBUG_DEFINE);
+            if (enabled)
+            {
+                if (GUILayout.Button("Disable Debug Mode (Recommended)"))
+                {
+                    definesSplit.Remove(SABRE_CSG_DEBUG_DEFINE);
+                    defines = string.Join(";", definesSplit.ToArray());
+                    PlayerSettings.SetScriptingDefineSymbolsForGroup(buildTargetGroup, defines);
+                }
+            }
+            else
+            {
+                if (GUILayout.Button("Enable Debug Mode (Not Recommended)"))
+                {
+                    if (!definesSplit.Contains(SABRE_CSG_DEBUG_DEFINE))
+                    {
+                        definesSplit.Add(SABRE_CSG_DEBUG_DEFINE);
                     }
                     defines = string.Join(";", definesSplit.ToArray());
                     PlayerSettings.SetScriptingDefineSymbolsForGroup(buildTargetGroup, defines);


### PR DESCRIPTION
This is a great feature for now and in the future to let us keep important checks, unit tests, error logs... without potentially negatively impacting the end user and slowing down their system unnecessarily.