### PR TITLE
Cleanup and documentation: EPSILON

### DIFF
--- a/Scripts/Core/CSG/Edge.cs
+++ b/Scripts/Core/CSG/Edge.cs
@@ -11,12 +11,6 @@ namespace Sabresaurus.SabreCSG
     public class Edge
     {
         /// <summary>
-        /// Since floating-point math is imprecise we use a smaller value of 0.00001 (1e-5f) to check
-        /// for equality of two floats instead of absolute zero.
-        /// </summary>
-        public const float EPSILON = 1e-5f;
-
-        /// <summary>
         /// The first <see cref="Vertex"/> of the <see cref="Edge"/>.
         /// </summary>
         private Vertex vertex1;
@@ -131,7 +125,7 @@ namespace Sabresaurus.SabreCSG
 
             float dot = Vector3.Dot(direction1.normalized, direction2.normalized);
 
-            return Mathf.Abs(dot) > 1 - EPSILON;
+            return Mathf.Abs(dot) > 1 - MathHelper.EPSILON_5;
         }
 
         /// <summary>

--- a/Scripts/Core/CSG/Polygon.cs
+++ b/Scripts/Core/CSG/Polygon.cs
@@ -513,15 +513,36 @@ namespace Sabresaurus.SabreCSG
         }
 
         #region Comparator Classes
+
+        /// <summary>
+        /// An implementation of <see cref="IEqualityComparer{T}"/> that checks whether two <see
+        /// cref="Vector3"/> can be considered equal.
+        /// <para>Floating point inaccuracies are taken into account (see <see cref="MathHelper.EPSILON_3"/>).</para>
+        /// </summary>
+        /// <seealso cref="System.Collections.Generic.IEqualityComparer{UnityEngine.Vector3}"/>
         public class Vector3ComparerEpsilon : IEqualityComparer<Vector3>
         {
+            /// <summary>
+            /// Checks whether two <see cref="Vector3"/> can be considered equal.
+            /// </summary>
+            /// <param name="a">The first <see cref="Vector3"/>.</param>
+            /// <param name="b">The second <see cref="Vector3"/>.</param>
+            /// <returns><c>true</c> if the two <see cref="Vector3"/> can be considered equal; otherwise, <c>false</c>.</returns>
             public bool Equals(Vector3 a, Vector3 b)
             {
-                return Mathf.Abs(a.x - b.x) < EPSILON_LOWER
-                    && Mathf.Abs(a.y - b.y) < EPSILON_LOWER
-                        && Mathf.Abs(a.z - b.z) < EPSILON_LOWER;
+                return Mathf.Abs(a.x - b.x) < MathHelper.EPSILON_3
+                    && Mathf.Abs(a.y - b.y) < MathHelper.EPSILON_3
+                    && Mathf.Abs(a.z - b.z) < MathHelper.EPSILON_3;
             }
 
+            /// <summary>
+            /// Returns a hash code for this instance.
+            /// </summary>
+            /// <param name="obj">The object to hash.</param>
+            /// <returns>
+            /// A hash code for this instance, suitable for use in hashing algorithms and data structures
+            /// like a hash table.
+            /// </returns>
             public int GetHashCode(Vector3 obj)
             {
                 // The similarity or difference between two positions can only be calculated if both are supplied
@@ -532,13 +553,36 @@ namespace Sabresaurus.SabreCSG
             }
         }
 
-        public class VertexComparerEpsilon : IEqualityComparer<Vertex>
+        /// <summary>
+        /// An implementation of <see cref="IEqualityComparer{T}"/> that checks whether two <see
+        /// cref="Vertex"/> can be considered equal by their position alone.
+        /// <para>
+        /// Floating point inaccuracies are taken into account (see <see
+        /// cref="Extensions.EqualsWithEpsilon(UnityEngine.Vector3, UnityEngine.Vector3)"/>).
+        /// </para>
+        /// </summary>
+        /// <seealso cref="System.Collections.Generic.IEqualityComparer{Sabresaurus.SabreCSG.Vertex}"/>
+        public class VertexComparerEpsilon : IEqualityComparer<Vertex> // should be renamed to VertexPositionComparerEpsilon
         {
-            public bool Equals(Vertex x, Vertex y)
+            /// <summary>
+            /// Checks whether two <see cref="Vertex"/> can be considered equal by their position.
+            /// </summary>
+            /// <param name="a">The first <see cref="Vertex"/>.</param>
+            /// <param name="b">The second <see cref="Vertex"/>.</param>
+            /// <returns><c>true</c> if the two <see cref="Vertex"/> can be considered equal; otherwise, <c>false</c>.</returns>
+            public bool Equals(Vertex a, Vertex b)
             {
-                return x.Position.EqualsWithEpsilon(y.Position);
+                return a.Position.EqualsWithEpsilon(b.Position);
             }
 
+            /// <summary>
+            /// Returns a hash code for this instance.
+            /// </summary>
+            /// <param name="obj">The object to hash.</param>
+            /// <returns>
+            /// A hash code for this instance, suitable for use in hashing algorithms and data structures
+            /// like a hash table.
+            /// </returns>
             public int GetHashCode(Vertex obj)
             {
                 // The similarity or difference between two positions can only be calculated if both are supplied
@@ -549,27 +593,41 @@ namespace Sabresaurus.SabreCSG
             }
         }
 
+        /// <summary>
+        /// An implementation of <see cref="IEqualityComparer{T}"/> that checks whether two <see
+        /// cref="Polygon"/> can be considered equal by their unique index.
+        /// </summary>
+        /// <seealso cref="System.Collections.Generic.IEqualityComparer{Sabresaurus.SabreCSG.Polygon}"/>
         public class PolygonUIDComparer : IEqualityComparer<Polygon>
         {
-            public bool Equals(Polygon x, Polygon y)
+            /// <summary>
+            /// Checks whether two <see cref="Polygon"/> have the same unique index.
+            /// </summary>
+            /// <param name="a">The first <see cref="Polygon"/>.</param>
+            /// <param name="b">The second <see cref="Polygon"/>.</param>
+            /// <returns><c>true</c> if the two <see cref="Polygon"/> have the same unique index; otherwise, <c>false</c>.</returns>
+            public bool Equals(Polygon a, Polygon b)
             {
-                return x.UniqueIndex == y.UniqueIndex;
+                return a.UniqueIndex == b.UniqueIndex;
             }
 
+            /// <summary>
+            /// Returns a hash code for this instance.
+            /// </summary>
+            /// <param name="obj">The object to hash.</param>
+            /// <returns>
+            /// A hash code for this instance, suitable for use in hashing algorithms and data structures
+            /// like a hash table.
+            /// </returns>
             public int GetHashCode(Polygon obj)
             {
                 return base.GetHashCode();
             }
         }
 
-        #endregion
+        #endregion Comparator Classes
 
         #region Static Methods
-
-        private const float EPSILON = 0.00001f;
-        private const float EPSILON_LOWER = 0.001f;
-
-        //		const float EPSILON_LOWER = 0.003f;
 
         public enum PolygonPlaneRelation { InFront, Behind, Spanning, Coplanar };
 
@@ -587,11 +645,11 @@ namespace Sabresaurus.SabreCSG
             for (int i = 0; i < polygon.Vertices.Length; i++)
             {
                 float distance = testPlane.GetDistanceToPoint(polygon.Vertices[i].Position);
-                if (distance < -EPSILON_LOWER) // Is the point in front of the plane (with thickness)
+                if (distance < -MathHelper.EPSILON_3) // Is the point in front of the plane (with thickness)
                 {
                     verticesInFront++;
                 }
-                else if (distance > EPSILON_LOWER) // Is the point behind the plane (with thickness)
+                else if (distance > MathHelper.EPSILON_3) // Is the point behind the plane (with thickness)
                 {
                     verticesBehind++;
                 }
@@ -814,11 +872,11 @@ namespace Sabresaurus.SabreCSG
         public static PointPlaneRelation ComparePointToPlane2(Vector3 point, Plane plane)
         {
             float distance = plane.GetDistanceToPoint(point);
-            if (distance < -EPSILON)
+            if (distance < -MathHelper.EPSILON_5)
             {
                 return PointPlaneRelation.InFront;
             }
-            else if (distance > EPSILON)
+            else if (distance > MathHelper.EPSILON_5)
             {
                 return PointPlaneRelation.Behind;
             }
@@ -831,11 +889,11 @@ namespace Sabresaurus.SabreCSG
         public static PointPlaneRelation ComparePointToPlane(Vector3 point, Plane plane)
         {
             float distance = plane.GetDistanceToPoint(point);
-            if (distance < -EPSILON_LOWER)
+            if (distance < -MathHelper.EPSILON_3)
             {
                 return PointPlaneRelation.InFront;
             }
-            else if (distance > EPSILON_LOWER)
+            else if (distance > MathHelper.EPSILON_3)
             {
                 return PointPlaneRelation.Behind;
             }

--- a/Scripts/Core/IDeepCopyable.cs
+++ b/Scripts/Core/IDeepCopyable.cs
@@ -4,12 +4,19 @@ using UnityEngine;
 
 namespace Sabresaurus.SabreCSG
 {
-	public interface IDeepCopyable<T>
-	{
-		T DeepCopy();
-	}
+    /// <summary>Supports deep copying, which creates a new instance of a class with the same value as an existing instance.</summary>
+    /// <typeparam name="T">The class type.</typeparam>
+    public interface IDeepCopyable<T>
+    {
+        /// <summary>
+        /// Creates a deep copy of the <typeparamref name="T"/>. Returns a new instance of a
+        /// <typeparamref name="T"/> with the same value as this instance.
+        /// </summary>
+        /// <returns>The newly created <typeparamref name="T"/> copy with the same values.</returns>
+        T DeepCopy();
+    }
 
-	public static class DeepCopyableExtensions
+    public static class DeepCopyableExtensions
 	{
 		public static T[] DeepCopy<T>(this T[] sourceArray) where T : IDeepCopyable<T>
 		{

--- a/Scripts/Extensions/Extensions.cs
+++ b/Scripts/Extensions/Extensions.cs
@@ -8,11 +8,6 @@ namespace Sabresaurus.SabreCSG
 {
     public static class Extensions
     {
-        private const float EPSILON = 1e-5f;
-        private const float EPSILON_LOWER = 1e-4f;
-        private const float EPSILON_LOWER_2 = 1e-3f;
-        private const float EPSILON_LOWER_3 = 1e-2f;
-
         public static Vector3 Abs(this Vector3 a)
         {
             return new Vector3(Mathf.Abs(a.x), Mathf.Abs(a.y), Mathf.Abs(a.z));
@@ -343,7 +338,7 @@ namespace Sabresaurus.SabreCSG
 
         public static bool EqualsWithEpsilon(this float a, float b)
         {
-            return Mathf.Abs(a - b) < EPSILON;
+            return Mathf.Abs(a - b) < MathHelper.EPSILON_5;
         }
 
         /// <summary>
@@ -351,17 +346,17 @@ namespace Sabresaurus.SabreCSG
         /// </summary>
         public static bool EqualsWithEpsilon(this Vector3 a, Vector3 b)
         {
-            return Mathf.Abs(a.x - b.x) < EPSILON && Mathf.Abs(a.y - b.y) < EPSILON && Mathf.Abs(a.z - b.z) < EPSILON;
+            return Mathf.Abs(a.x - b.x) < MathHelper.EPSILON_5 && Mathf.Abs(a.y - b.y) < MathHelper.EPSILON_5 && Mathf.Abs(a.z - b.z) < MathHelper.EPSILON_5;
         }
 
         public static bool EqualsWithEpsilonLower(this Vector3 a, Vector3 b)
         {
-            return Mathf.Abs(a.x - b.x) < EPSILON_LOWER && Mathf.Abs(a.y - b.y) < EPSILON_LOWER && Mathf.Abs(a.z - b.z) < EPSILON_LOWER;
+            return Mathf.Abs(a.x - b.x) < MathHelper.EPSILON_4 && Mathf.Abs(a.y - b.y) < MathHelper.EPSILON_4 && Mathf.Abs(a.z - b.z) < MathHelper.EPSILON_4;
         }
 
         public static bool EqualsWithEpsilonLower3(this Vector3 a, Vector3 b)
         {
-            return Mathf.Abs(a.x - b.x) < EPSILON_LOWER_3 && Mathf.Abs(a.y - b.y) < EPSILON_LOWER_3 && Mathf.Abs(a.z - b.z) < EPSILON_LOWER_3;
+            return Mathf.Abs(a.x - b.x) < MathHelper.EPSILON_2 && Mathf.Abs(a.y - b.y) < MathHelper.EPSILON_2 && Mathf.Abs(a.z - b.z) < MathHelper.EPSILON_2;
         }
 
         public static Rect ExpandFromCenter(this Rect rect, Vector2 expansion)
@@ -386,12 +381,12 @@ namespace Sabresaurus.SabreCSG
         internal static bool IntersectsApproximate(this Bounds bounds1, Bounds bounds2)
         {
             //		return bounds1.min.x-EPSILON <= bounds2.max.x && bounds1.max.x+EPSILON >= bounds2.min.x && bounds1.min.y-EPSILON <= bounds2.max.y && bounds1.max.y+EPSILON >= bounds2.min.y && bounds1.min.z-EPSILON <= bounds2.max.z && bounds1.max.z+EPSILON >= bounds2.min.z;
-            return bounds1.min.x - EPSILON_LOWER_2 <= bounds2.max.x
-                && bounds1.max.x + EPSILON_LOWER_2 >= bounds2.min.x
-                && bounds1.min.y - EPSILON_LOWER_2 <= bounds2.max.y
-                && bounds1.max.y + EPSILON_LOWER_2 >= bounds2.min.y
-                && bounds1.min.z - EPSILON_LOWER_2 <= bounds2.max.z
-                && bounds1.max.z + EPSILON_LOWER_2 >= bounds2.min.z;
+            return bounds1.min.x - MathHelper.EPSILON_3 <= bounds2.max.x
+                && bounds1.max.x + MathHelper.EPSILON_3 >= bounds2.min.x
+                && bounds1.min.y - MathHelper.EPSILON_3 <= bounds2.max.y
+                && bounds1.max.y + MathHelper.EPSILON_3 >= bounds2.min.y
+                && bounds1.min.z - MathHelper.EPSILON_3 <= bounds2.max.z
+                && bounds1.max.z + MathHelper.EPSILON_3 >= bounds2.min.z;
         }
 
         // If the second bounds has a coplanar side then it is considered not contained
@@ -407,12 +402,12 @@ namespace Sabresaurus.SabreCSG
 
         internal static bool ContainsApproximate(this Bounds bounds1, Vector3 point)
         {
-            return (point.x > bounds1.min.x - EPSILON_LOWER_2
-                && point.y > bounds1.min.y - EPSILON_LOWER_2
-                && point.z > bounds1.min.z - EPSILON_LOWER_2
-                && point.x < bounds1.max.x + EPSILON_LOWER_2
-                && point.y < bounds1.max.y + EPSILON_LOWER_2
-                && point.z < bounds1.max.z + EPSILON_LOWER_2);
+            return (point.x > bounds1.min.x - MathHelper.EPSILON_3
+                && point.y > bounds1.min.y - MathHelper.EPSILON_3
+                && point.z > bounds1.min.z - MathHelper.EPSILON_3
+                && point.x < bounds1.max.x + MathHelper.EPSILON_3
+                && point.y < bounds1.max.y + MathHelper.EPSILON_3
+                && point.z < bounds1.max.z + MathHelper.EPSILON_3);
         }
 
         /// <summary>

--- a/Scripts/Extensions/MathHelper.cs
+++ b/Scripts/Extensions/MathHelper.cs
@@ -4,9 +4,31 @@ namespace Sabresaurus.SabreCSG
 {
 	public static class MathHelper
 	{
-        const float EPSILON_LOWER = 0.0001f;
-        const float EPSILON_LOWER_2 = 0.001f;
-        const float EPSILON_LOWER_3 = 0.003f;
+        /// <summary>
+        /// Since floating-point math is imprecise we use a smaller value of 0.00001 (1e-5f) to check
+        /// for equality of two floats instead of absolute zero.
+        /// </summary>
+        public const float EPSILON_5 = 1e-5f;
+        /// <summary>
+        /// Since floating-point math is imprecise we use a smaller value of 0.0001 (1e-4f).
+        /// </summary>
+        public const float EPSILON_4 = 1e-4f;
+        /// <summary>
+        /// Since floating-point math is imprecise we use a smaller value of 0.001 (1e-3f).
+        /// </summary>
+        public const float EPSILON_3 = 1e-3f;
+        /// <summary>
+        /// Since floating-point math is imprecise we use a smaller value of 0.01 (1e-2f).
+        /// </summary>
+        public const float EPSILON_2 = 1e-2f;
+        /// <summary>
+        /// Since floating-point math is imprecise we use a smaller value of 0.1 (1e-1f).
+        /// </summary>
+        public const float EPSILON_1 = 1e-1f;
+        /// <summary>
+        /// Since floating-point math is imprecise we use a smaller value of 0.003.
+        /// </summary>
+        public const float EPSILON_3_3 = 0.003f;
 
         public static int GetSideThick(Plane plane, Vector3 point)
         {
@@ -296,10 +318,10 @@ namespace Sabresaurus.SabreCSG
 		public static bool PlaneEqualsLooser(Plane plane1, Plane plane2)
 		{
 			if(
-				Mathf.Abs(plane1.distance - plane2.distance) < EPSILON_LOWER
-				&& Mathf.Abs(plane1.normal.x - plane2.normal.x) < EPSILON_LOWER 
-				&& Mathf.Abs(plane1.normal.y - plane2.normal.y) < EPSILON_LOWER 
-				&& Mathf.Abs(plane1.normal.z - plane2.normal.z) < EPSILON_LOWER)
+				Mathf.Abs(plane1.distance - plane2.distance) < EPSILON_4
+                && Mathf.Abs(plane1.normal.x - plane2.normal.x) < EPSILON_4
+                && Mathf.Abs(plane1.normal.y - plane2.normal.y) < EPSILON_4
+                && Mathf.Abs(plane1.normal.z - plane2.normal.z) < EPSILON_4)
 			{
 				return true;
 			}

--- a/Scripts/Geometry/GeometryHelper.cs
+++ b/Scripts/Geometry/GeometryHelper.cs
@@ -23,14 +23,6 @@ namespace Sabresaurus.SabreCSG
 	/// </summary>
 	public static class GeometryHelper
 	{
-        const float TEST_EPSILON = 0.003f;
-        private const float CONVEX_EPSILON = 0.01f;
-
-        const float EPSILON = 1e-5f; // Used to avoid floating point test issues, e.g. -0.000001 may be considered 0
-        const float EPSILON_LOWER = 1e-4f;
-        const float EPSILON_LOWER_2 = 1e-3f;
-
-
         /// <summary>
         /// Determines if a set of polygons represent a convex brush with planar polygons
         /// </summary>
@@ -55,7 +47,7 @@ namespace Sabresaurus.SabreCSG
 
 							float dot = Vector3.Dot(polygonPlane.normal, polygons[n].Vertices[k].Position) + polygonPlane.distance;
 
-							if(dot > CONVEX_EPSILON)
+							if(dot > MathHelper.EPSILON_2)
 							{
 								return false;
 							}
@@ -70,7 +62,7 @@ namespace Sabresaurus.SabreCSG
 
 							float dot = Vector3.Dot(polygonPlane.normal, polygons[n].Vertices[k].Position) + polygonPlane.distance;
 
-							if(dot > CONVEX_EPSILON)
+							if(dot > MathHelper.EPSILON_2)
 							{
 								return false;
 							}
@@ -273,13 +265,13 @@ namespace Sabresaurus.SabreCSG
 
 					float distance = testPlane.GetDistanceToPoint(point);
 
-					if (distance < -TEST_EPSILON)
+					if (distance < -MathHelper.EPSILON_3_3)
 					{
 						numberInFront++;
 
 						distanceInFront = Mathf.Min(distanceInFront, distance);
 					}
-					else if (distance > TEST_EPSILON)
+					else if (distance > MathHelper.EPSILON_3_3)
 					{
 						numberBehind++;
 
@@ -436,7 +428,7 @@ namespace Sabresaurus.SabreCSG
                 Plane plane = polygons[i].Plane;
                 // Use positive epsilon
                 float distance = Vector3.Dot(plane.normal, point) + plane.distance;
-                if (distance > EPSILON_LOWER)
+                if (distance > MathHelper.EPSILON_4)
                 {
                     return false;
                 }
@@ -451,7 +443,7 @@ namespace Sabresaurus.SabreCSG
                 Plane plane = polygons[i].Plane;
                 // Use positive epsilon
                 float distance = Vector3.Dot(plane.normal, point) + plane.distance;
-                if (distance > EPSILON_LOWER_2)
+                if (distance > MathHelper.EPSILON_3)
                 {
                     return false;
                 }
@@ -530,7 +522,7 @@ namespace Sabresaurus.SabreCSG
                 // No epsilon here
                 //				if(Vector3.Dot (plane.normal, point) + plane.distance >= 0f)
                 float dist = Vector3.Dot(plane.normal, point) + plane.distance;
-                if (dist > EPSILON)
+                if (dist > MathHelper.EPSILON_5)
                 {
                     return false;
                 }
@@ -551,7 +543,7 @@ namespace Sabresaurus.SabreCSG
                 {
                     bestDistance = distance;
                 }
-                if (bestDistance < -EPSILON)
+                if (bestDistance < -MathHelper.EPSILON_5)
                 {
                     return -1;
                 }
@@ -565,7 +557,7 @@ namespace Sabresaurus.SabreCSG
             {
                 Plane plane = polygons[i].Plane;
                 // Use negative epsilon
-                if (Vector3.Dot(plane.normal, point) + plane.distance >= -EPSILON)
+                if (Vector3.Dot(plane.normal, point) + plane.distance >= -MathHelper.EPSILON_5)
                 {
                     return false;
                 }
@@ -579,7 +571,7 @@ namespace Sabresaurus.SabreCSG
             {
                 Plane plane = polygons[i].Plane;
                 // Use negative epsilon
-                if (Vector3.Dot(plane.normal, point) + plane.distance >= -EPSILON)
+                if (Vector3.Dot(plane.normal, point) + plane.distance >= -MathHelper.EPSILON_5)
                 {
                     return false;
                 }


### PR DESCRIPTION
Added generic EPSILON constants to Scripts/Extensions/MathHelper.cs that all of SabreCSG uses to keep things consistent and easy to swap & find references in the future for the move to fixed point.

Additional documentation for the `Polygon.Vector3ComparerEpsilon`, `Polygon.VertexComparerEpsilon`, `Polygon.PolygonUIDComparer` and `Polygon.IDeepCopyable<T>` so that the cleanup project branch can be closed.