### PR TITLE
Fixed projected grid scaling issue

### DIFF
--- a/Internal/Shaders/BrushPreview.shader
+++ b/Internal/Shaders/BrushPreview.shader
@@ -54,7 +54,7 @@ Shader "SabreCSG/BrushPreview"
 				worldNormal.z = (worldNormal.z > worldNormal.y && worldNormal.z > worldNormal.x)?1:0;
 
 				float3 worldspace = IN.worldPos;
-				worldspace -= _GridThickness * 0.5;
+				worldspace -= (_GridThickness * _GridSize) * 0.5;
 
 				float2 grid = float2(
 					(worldspace.z * worldNormal.x) + (worldspace.x * worldNormal.z) + (worldspace.x * worldNormal.y),


### PR DESCRIPTION
We didn't notice this until it was too late:

![image](https://user-images.githubusercontent.com/7905726/48307947-81a8b480-e558-11e8-9b71-65545f4a06e1.png)

The problem has been fixed:

![image](https://user-images.githubusercontent.com/7905726/48307953-a13fdd00-e558-11e8-8c81-e2968b306260.png)