### PR TITLE
Make Projected Grid render better in dark areas and lit scenes

### DIFF
--- a/Internal/Shaders/BrushPreview.shader
+++ b/Internal/Shaders/BrushPreview.shader
@@ -67,10 +67,8 @@ Shader "SabreCSG/BrushPreview"
 				grid.y = step((1.0 - _GridThickness)*_GridSize, mod(grid.y, _GridSize));
 
 				float g = saturate(grid.x + grid.y);
-
-				//o.Alpha = g;
-
-				o.Albedo = c.rgb + (g * _GridStrength * _GridToggle);
+                
+				o.Emission = c.rgb + (g * _GridStrength * _GridToggle);
 				o.Alpha = c.a + (g * _GridStrength * _GridToggle);
 			}
 		ENDCG


### PR DESCRIPTION
Made the color channel use `o.Emission` instead of `o.Albedo` to avoid rendering with scene lighting, helping with grid visibility in dark areas, or on dark materials.

![image](https://user-images.githubusercontent.com/355687/48309409-23bba300-e53f-11e8-8846-06f382734632.png)
