### PR TITLE
Projected Grid Anti Aliasing and Depth Stability

### DIFF
--- a/Internal/Shaders/BrushPreview.shader
+++ b/Internal/Shaders/BrushPreview.shader
@@ -4,9 +4,8 @@ Shader "SabreCSG/BrushPreview"
 	Properties
 	{
 		_Color ("Main Color", Color) = (1,1,1,1)
-		_GridSize("Grid Size", float) = 1.0
-		_GridStrength("Grid Strength", Range(0,1)) = 0.25
-		_GridThickness("Grid Thickness", Range(0.01,0.1)) = 0.05
+		_GridAlpha("Grid Alpha", Range(0,1)) = 0.3
+		[HideInInspector] _GridSize("Grid Size", float) = 1.0
 		[HideInInspector] _GridToggle("Grid Toggle", float) = 1.0
 		[HideInInspector] _FaceToggle("Face Toggle", float) = 1.0
 	}
@@ -21,9 +20,8 @@ Shader "SabreCSG/BrushPreview"
 			#pragma surface surf Lambert alpha:blend nofog
 
 			fixed4 _Color;
-			float _GridStrength;
+			float _GridAlpha;
 			float _GridSize;
-			float _GridThickness;
 			half _GridToggle;
 			half _FaceToggle;
 
@@ -44,6 +42,12 @@ Shader "SabreCSG/BrushPreview"
 
 			void surf (Input IN, inout SurfaceOutput o)
 			{
+				float dist = distance(_WorldSpaceCameraPos, IN.worldPos);
+				float gridThickness = max(0.08, smoothstep(0.0, 1.0, dist / 80.0));
+
+				// counteract subpixel grid lines on small grid sizes.
+				gridThickness += lerp(log2(1/_GridSize)*0.25, 0.0, min(1.0, _GridSize));
+
 				fixed4 c = _Color;
 				c.a *= _FaceToggle;
 
@@ -54,7 +58,7 @@ Shader "SabreCSG/BrushPreview"
 				worldNormal.z = (worldNormal.z > worldNormal.y && worldNormal.z > worldNormal.x)?1:0;
 
 				float3 worldspace = IN.worldPos;
-				worldspace -= (_GridThickness * _GridSize) * 0.5;
+				worldspace -= (gridThickness * _GridSize) / 6.28;
 
 				float2 grid = float2(
 					(worldspace.z * worldNormal.x) + (worldspace.x * worldNormal.z) + (worldspace.x * worldNormal.y),
@@ -63,13 +67,16 @@ Shader "SabreCSG/BrushPreview"
 
 				_GridSize = max(0.01, _GridSize);
 
-				grid.x = step((1.0 - _GridThickness)*_GridSize, mod(grid.x, _GridSize));
-				grid.y = step((1.0 - _GridThickness)*_GridSize, mod(grid.y, _GridSize));
+				grid.x = mod(grid.x,_GridSize);
+				grid.y = mod(grid.y,_GridSize);
+
+				grid.x = saturate(1.0 - sin(grid.x * ((3.14/_GridSize)+gridThickness/_GridSize)) * 30);
+				grid.y = saturate(1.0 - sin(grid.y * ((3.14/_GridSize)+gridThickness/_GridSize)) * 30);
 
 				float g = saturate(grid.x + grid.y);
-                
-				o.Emission = c.rgb + (g * _GridStrength * _GridToggle);
-				o.Alpha = c.a + (g * _GridStrength * _GridToggle);
+
+				o.Emission = c.rgb + (g * _GridAlpha * _GridToggle);
+				o.Alpha = c.a + (g * _GridAlpha * _GridToggle);
 			}
 		ENDCG
 	}

--- a/Internal/Shaders/BrushPreview.shader
+++ b/Internal/Shaders/BrushPreview.shader
@@ -43,10 +43,12 @@ Shader "SabreCSG/BrushPreview"
 			void surf (Input IN, inout SurfaceOutput o)
 			{
 				float dist = distance(_WorldSpaceCameraPos, IN.worldPos);
-				float gridThickness = max(0.08, smoothstep(0.0, 1.0, dist / 80.0));
+				float len = lerp(20, 140, min(1.0, _GridSize));
+				float m = smoothstep(0.0, 1.0, dist / len);
+				float gridThickness = max(0.03, m);
 
 				// counteract subpixel grid lines on small grid sizes.
-				gridThickness += lerp(log2(1/_GridSize)*0.25, 0.0, min(1.0, _GridSize));
+				gridThickness += lerp(0.0, lerp(log2(1/_GridSize)*0.25, 0.0, min(1.0, _GridSize)), m);
 
 				fixed4 c = _Color;
 				c.a *= _FaceToggle;
@@ -70,8 +72,8 @@ Shader "SabreCSG/BrushPreview"
 				grid.x = mod(grid.x,_GridSize);
 				grid.y = mod(grid.y,_GridSize);
 
-				grid.x = saturate(1.0 - sin(grid.x * ((3.14/_GridSize)+gridThickness/_GridSize)) * 30);
-				grid.y = saturate(1.0 - sin(grid.y * ((3.14/_GridSize)+gridThickness/_GridSize)) * 30);
+				grid.x = saturate(1.0 - sin(grid.x * ((3.14/_GridSize)+gridThickness/_GridSize)) * (30 * _GridSize));
+				grid.y = saturate(1.0 - sin(grid.y * ((3.14/_GridSize)+gridThickness/_GridSize)) * (30 * _GridSize));
 
 				float g = saturate(grid.x + grid.y);
 

--- a/Scripts/CurrentSettings.cs
+++ b/Scripts/CurrentSettings.cs
@@ -224,7 +224,7 @@ namespace Sabresaurus.SabreCSG
         {
             get
             {
-                return PlayerPrefs.GetInt(KEY_PREFIX + "ProjectedGridEnabled", 1) != 0;
+                return PlayerPrefs.GetInt(KEY_PREFIX + "ProjectedGridEnabled", 0) != 0;
             }
             set
             {

--- a/Scripts/UI/Toolbar.cs
+++ b/Scripts/UI/Toolbar.cs
@@ -370,7 +370,7 @@ namespace Sabresaurus.SabreCSG
             toggleProjectedGridStyle.fixedHeight = 18;
 
             bool lastProjectedGridEnabled = CurrentSettings.ProjectedGridEnabled;
-            CurrentSettings.ProjectedGridEnabled = GUILayout.Toggle(CurrentSettings.ProjectedGridEnabled, SabreCSGResources.ButtonProjectedGridTexture, toggleProjectedGridStyle);
+            CurrentSettings.ProjectedGridEnabled = GUILayout.Toggle(CurrentSettings.ProjectedGridEnabled, new GUIContent(SabreCSGResources.ButtonProjectedGridTexture, "Toggle Projected Grid"), toggleProjectedGridStyle);
             if (CurrentSettings.ProjectedGridEnabled != lastProjectedGridEnabled)
             {
                 SceneView.RepaintAll();


### PR DESCRIPTION
A huge thanks to @jmickle66666666 for the anti-aliasing code and supporting me with complex math equations.

* The grid thickness is calculated automatically to counteract depth fighting issues.
* Lines have anti-aliasing to prevent pixelated noise.
* The grid size has been hidden from the inspector.
* Disabled the projected grid by default to not overwhelm new users, they would have to search how to disable it which is more frustrating than suddenly discovering this feature.
* Added a tooltip to the toolbar button that toggles the projected grid.

![It works with tiny grids](https://user-images.githubusercontent.com/7905726/48313432-ad5d8600-e5bc-11e8-862f-4b8c806da57b.png)