### PR TITLE
Fixed null reference error with auto rebuild and toolbar timers.

### DIFF
--- a/Scripts/CSGModelBase.cs
+++ b/Scripts/CSGModelBase.cs
@@ -227,6 +227,10 @@ namespace Sabresaurus.SabreCSG
                 Debug.LogError("Default fallback material file is missing, try reimporting SabreCSG");
             }
 
+            // Make sure the build context has been initialized.
+            if (buildContext == null)
+                buildContext = BuildContext;
+
             BuildStatus buildStatus = CSGFactory.Build(brushes,
                 buildSettings,
                 buildContext,


### PR DESCRIPTION
The debug timers in the toolbar initialize the build context, with them disabled auto rebuild will throw null reference exceptions. We must assume there was a perfectly valid reason to program it this way, we are simply not capable of understanding this superior logic. 😄