### PR TITLE
Alternative way of snapping bounds to the grid

### DIFF
--- a/Scripts/CSGModel.cs
+++ b/Scripts/CSGModel.cs
@@ -763,6 +763,16 @@ namespace Sabresaurus.SabreCSG
                 }
                 e.Use();
             }
+            else if ((KeyMappings.EventsMatch(e, Event.KeyboardEvent(KeyMappings.Instance.SnapSelectionToCurrentGrid)))) {
+                if (e.type == EventType.KeyDown)
+                {
+                    CurrentSettings.SnapSelectionToCurrentGrid = true;
+                }
+                else {
+                    CurrentSettings.SnapSelectionToCurrentGrid = false;
+                }
+                e.Use();
+            }
             else if (!MouseIsHeld && KeyMappings.EventsMatch(e, Event.KeyboardEvent(KeyMappings.Instance.ActivateClipMode)))
             {
                 // Activate mode - immediately (key down)

--- a/Scripts/CSGModel.cs
+++ b/Scripts/CSGModel.cs
@@ -763,16 +763,6 @@ namespace Sabresaurus.SabreCSG
                 }
                 e.Use();
             }
-            else if ((KeyMappings.EventsMatch(e, Event.KeyboardEvent(KeyMappings.Instance.SnapSelectionToCurrentGrid)))) {
-                if (e.type == EventType.KeyDown)
-                {
-                    CurrentSettings.SnapSelectionToCurrentGrid = true;
-                }
-                else {
-                    CurrentSettings.SnapSelectionToCurrentGrid = false;
-                }
-                e.Use();
-            }
             else if (!MouseIsHeld && KeyMappings.EventsMatch(e, Event.KeyboardEvent(KeyMappings.Instance.ActivateClipMode)))
             {
                 // Activate mode - immediately (key down)

--- a/Scripts/CurrentSettings.cs
+++ b/Scripts/CurrentSettings.cs
@@ -372,15 +372,6 @@ namespace Sabresaurus.SabreCSG
                 PlayerPrefs.SetInt(KEY_PREFIX + "alwaysSnapToCurrentGrid", value ? 1 : 0);
             }
         }
-
-        public static bool SnapSelectionToCurrentGrid {
-            get {
-                return Instance.snapSelectionToCurrentGrid || AlwaysSnapToCurrentGrid;
-            }
-            set {
-                Instance.snapSelectionToCurrentGrid = value;
-            }
-        }
     }
 }
 

--- a/Scripts/CurrentSettings.cs
+++ b/Scripts/CurrentSettings.cs
@@ -38,6 +38,8 @@ namespace Sabresaurus.SabreCSG
     {
         private bool brushesHidden = false;
         private bool meshHidden = false;
+        private bool snapSelectionToCurrentGrid;
+        private bool alwaysSnapToCurrentGrid;
         private Material foregroundMaterial;
 
         private static CurrentSettings instance = null;
@@ -359,6 +361,24 @@ namespace Sabresaurus.SabreCSG
                 // Occassionally have experienced issues where camera locks up, resetting the Tools class seems to fix it
                 Tools.viewTool = ViewTool.None;
                 Tools.current = UnityEditor.Tool.None;
+            }
+        }
+
+        public static bool AlwaysSnapToCurrentGrid {
+            get {
+                return PlayerPrefs.GetInt(KEY_PREFIX + "alwaysSnapToCurrentGrid") == 1;
+            }
+            set {
+                PlayerPrefs.SetInt(KEY_PREFIX + "alwaysSnapToCurrentGrid", value ? 1 : 0);
+            }
+        }
+
+        public static bool SnapSelectionToCurrentGrid {
+            get {
+                return Instance.snapSelectionToCurrentGrid || AlwaysSnapToCurrentGrid;
+            }
+            set {
+                Instance.snapSelectionToCurrentGrid = value;
             }
         }
     }

--- a/Scripts/Input/KeyMappings.cs
+++ b/Scripts/Input/KeyMappings.cs
@@ -65,6 +65,7 @@ namespace Sabresaurus.SabreCSG
 		public string Ungroup = "#g";
 
 		public string EnableRadialMenu = "j";
+		public string SnapSelectionToCurrentGrid = "y";
 
 		[Header("Clip Tool")]
 		public string ApplyClip = "Return";

--- a/Scripts/Tools/ResizeEditor.cs
+++ b/Scripts/Tools/ResizeEditor.cs
@@ -1,7 +1,6 @@
 #if UNITY_EDITOR
 
 using UnityEngine;
-using System.Collections;
 using UnityEditor;
 using System.Linq;
 using System.Collections.Generic;
@@ -28,7 +27,11 @@ namespace Sabresaurus.SabreCSG
         private ResizeHandlePair? hoveredResizeHandlePair = null;
         private int hoveredResizePointIndex = -1; // -1 is unset, 0 is Point1, 1 is Point2
 
-        private Vector3 dotOffset3;
+        /// <summary>
+        /// The delta of the translation delta (damn right, delta delta!) when moving the brush selection
+        /// between the raw position and the position snapped to the current grid
+        /// </summary>
+        private Vector3 translationDeltaSnappingOffset;
 
         private float fullDeltaAngle = 0;
         private float unroundedDeltaAngle = 0;
@@ -599,7 +602,7 @@ namespace Sabresaurus.SabreCSG
                 else
                 {
                     // Resize
-                    dotOffset3 = Vector3.zero;
+                    translationDeltaSnappingOffset = Vector3.zero;
 
                     Vector2 mousePosition = e.mousePosition;
 
@@ -803,14 +806,10 @@ namespace Sabresaurus.SabreCSG
             Ray lastRay = Camera.current.ScreenPointToRay(EditorHelper.ConvertMousePointPosition(lastPosition));
 
             Ray currentRay = Camera.current.ScreenPointToRay(EditorHelper.ConvertMousePointPosition(currentPosition));
-
-            //			Bounds bounds = GetBounds();
-
-            Vector3 offset = primaryTargetBrushTransform.position;
-            //			if(Tools.pivotMode == PivotMode.Center && Tools.pivotRotation == PivotRotation.Global)
-            //			{
-            //				offset = GetBounds().center;
-            //			}
+            Bounds bounds = GetBounds();
+            // we use the current AABBs center as offset. it's more correct than the primary brushes transform.
+            // especially when dealing with selections of multiple brushes
+            Vector3 offset = TransformPoint(bounds.center);
 
             Vector3 lineStart = offset + TransformDirection(selectedResizeHandlePair.Value.point1);
             Vector3 lineEnd = offset + TransformDirection(selectedResizeHandlePair.Value.point2);
@@ -833,53 +832,68 @@ namespace Sabresaurus.SabreCSG
             {
                 direction = -direction;
             }
-
+            
             Vector3 deltaWorld = (currentPositionWorld - lastPositionWorld);
             // Rescaling logic deals with local space changes, convert to that space
             Vector3 deltaLocal = InverseTransformDirection(deltaWorld);
 
-            Vector3 dot3 = Vector3.zero;
+            Vector3 translationDelta = Vector3.zero;
             if (direction.x != 0)
             {
-                dot3.x = Vector3.Dot(deltaLocal, new Vector3(Mathf.Sign(direction.x), 0, 0));
+                translationDelta.x = Vector3.Dot(deltaLocal, new Vector3(Mathf.Sign(direction.x), 0, 0));
             }
             if (direction.y != 0)
             {
-                dot3.y = Vector3.Dot(deltaLocal, new Vector3(0, Mathf.Sign(direction.y), 0));
+                translationDelta.y = Vector3.Dot(deltaLocal, new Vector3(0, Mathf.Sign(direction.y), 0));
             }
             if (direction.z != 0)
             {
-                dot3.z = Vector3.Dot(deltaLocal, new Vector3(0, 0, Mathf.Sign(direction.z)));
+                translationDelta.z = Vector3.Dot(deltaLocal, new Vector3(0, 0, Mathf.Sign(direction.z)));
             }
 
-            float snapDistance = CurrentSettings.PositionSnapDistance;
+//            float snapDistance = CurrentSettings.PositionSnapDistance;
 
             if (CurrentSettings.PositionSnappingEnabled)
             {
-                // Snapping's dot uses an offset to track deltas that would be lost otherwise due to snapping
-                dot3 += dotOffset3;
+                float snapDistance = CurrentSettings.PositionSnapDistance;
 
-                Vector3 roundedDot3 = MathHelper.RoundVector3(dot3, snapDistance);
-                dotOffset3 = dot3 - roundedDot3;
-                dot3 = roundedDot3;
+                Vector3 snapDistanceOffset = Vector3.zero;
+                if (CurrentSettings.SnapSelectionToCurrentGrid) {
+                    // find the point we're dragging - that's the bounding box side or corner, if you will.
+                    Vector3 offsetReferencePoint = offset + direction.Multiply(bounds.size / 2f);
+                    // snap it to the global grid
+                    Vector3 snappedOffsetReferencePoint = MathHelper.RoundVector3(offsetReferencePoint, snapDistance);
+                    // get the delta between real and snap position. We gonna apply apply that to the snapped translation delta
+                    // to account for the fact that the face might be snapped to a smaller grid currently.
+                    // with this extra offset we will "re-snap" the face to the current grid
+                    snapDistanceOffset = offsetReferencePoint - snappedOffsetReferencePoint;
+                }
+                
+                
+                // Snapping's dot uses an offset to track deltas that would be lost otherwise due to snapping
+                translationDelta += translationDeltaSnappingOffset;
+
+                Vector3 snappedTranslationDelta = MathHelper.RoundVector3(translationDelta, snapDistance) - MathHelper.VectorAbs(snapDistanceOffset);
+                translationDeltaSnappingOffset = translationDelta - snappedTranslationDelta;
+                translationDelta = snappedTranslationDelta;
             }
 
             if (EnumHelper.IsFlagSet(e.modifiers, EventModifiers.Control))
             {
                 Undo.RecordObjects(targetBrushTransforms, "Move brush(es)");
-                dot3 = TransformDirection(dot3);
+                translationDelta = TransformDirection(translationDelta);
                 if (selectedResizePointIndex == 1)
                 {
-                    dot3 = -dot3;
+                    translationDelta = -translationDelta;
                 }
 
-                TranslateBrushes(dot3);
+                TranslateBrushes(translationDelta);
             }
             else
             {
                 if (GetIsValidToResize())
                 {
-                    RescaleBrush(direction, dot3);
+                    RescaleBrush(direction, translationDelta);
                 }
             }
         }

--- a/Scripts/Tools/ResizeEditor.cs
+++ b/Scripts/Tools/ResizeEditor.cs
@@ -72,6 +72,8 @@ namespace Sabresaurus.SabreCSG
         private Vector2 marqueeStart;
         private Vector2 marqueeEnd;
 
+        private bool inverseSnapSelectionToCurrentGridLogic = false;
+
         private ResizeHandlePair[] resizeHandlePairs = new ResizeHandlePair[]
         {
 			// Edge Mid Points
@@ -368,6 +370,18 @@ namespace Sabresaurus.SabreCSG
                         CancelMove();
                     }
                     e.Use();
+                }
+            }
+
+            if (KeyMappings.EventsMatch(e, Event.KeyboardEvent(KeyMappings.Instance.SnapSelectionToCurrentGrid)))
+            {
+                if (e.type == EventType.KeyDown)
+                {
+                    inverseSnapSelectionToCurrentGridLogic = true;
+                }
+                else
+                {
+                    inverseSnapSelectionToCurrentGridLogic = false;
                 }
             }
 
@@ -858,7 +872,8 @@ namespace Sabresaurus.SabreCSG
                 float snapDistance = CurrentSettings.PositionSnapDistance;
 
                 Vector3 snapDistanceOffset = Vector3.zero;
-                if (CurrentSettings.SnapSelectionToCurrentGrid) {
+
+                if (CurrentSettings.AlwaysSnapToCurrentGrid != inverseSnapSelectionToCurrentGridLogic) {
                     // find the point we're dragging - that's the bounding box side or corner, if you will.
                     Vector3 offsetReferencePoint = offset + direction.Multiply(bounds.extents);
                     // snap it to the global grid
@@ -868,7 +883,6 @@ namespace Sabresaurus.SabreCSG
                     // with this extra offset we will "re-snap" the face to the current grid
                     snapDistanceOffset = offsetReferencePoint - snappedOffsetReferencePoint;
                 }
-                
                 
                 // Snapping's dot uses an offset to track deltas that would be lost otherwise due to snapping
                 translationDelta += translationDeltaSnappingOffset;

--- a/Scripts/Tools/ResizeEditor.cs
+++ b/Scripts/Tools/ResizeEditor.cs
@@ -860,7 +860,7 @@ namespace Sabresaurus.SabreCSG
                 Vector3 snapDistanceOffset = Vector3.zero;
                 if (CurrentSettings.SnapSelectionToCurrentGrid) {
                     // find the point we're dragging - that's the bounding box side or corner, if you will.
-                    Vector3 offsetReferencePoint = offset + direction.Multiply(bounds.size / 2f);
+                    Vector3 offsetReferencePoint = offset + direction.Multiply(bounds.extents);
                     // snap it to the global grid
                     Vector3 snappedOffsetReferencePoint = MathHelper.RoundVector3(offsetReferencePoint, snapDistance);
                     // get the delta between real and snap position. We gonna apply apply that to the snapped translation delta
@@ -873,8 +873,9 @@ namespace Sabresaurus.SabreCSG
                 // Snapping's dot uses an offset to track deltas that would be lost otherwise due to snapping
                 translationDelta += translationDeltaSnappingOffset;
 
-                Vector3 snappedTranslationDelta = MathHelper.RoundVector3(translationDelta, snapDistance) - MathHelper.VectorAbs(snapDistanceOffset);
+                Vector3 snappedTranslationDelta = MathHelper.RoundVector3(translationDelta, snapDistance);
                 translationDeltaSnappingOffset = translationDelta - snappedTranslationDelta;
+                snappedTranslationDelta -= snapDistanceOffset;
                 translationDelta = snappedTranslationDelta;
             }
 

--- a/Scripts/Tools/VertexEditor.cs
+++ b/Scripts/Tools/VertexEditor.cs
@@ -34,7 +34,9 @@ namespace Sabresaurus.SabreCSG
 
         Vertex movingVertex;
 
-		void ClearSelection()
+        private bool inverseSnapSelectionToCurrentGridLogic = false;
+
+        void ClearSelection()
 		{
 			selectedEdges.Clear();
 			selectedVertices.Clear();
@@ -337,7 +339,7 @@ namespace Sabresaurus.SabreCSG
 				}
 			}
 
-			if (CurrentSettings.PositionSnappingEnabled && CurrentSettings.SnapSelectionToCurrentGrid) {
+			if (CurrentSettings.PositionSnappingEnabled && (CurrentSettings.AlwaysSnapToCurrentGrid != inverseSnapSelectionToCurrentGridLogic)) {
 				SnapSelectedVertices(true);
 			}
 		}
@@ -476,6 +478,11 @@ namespace Sabresaurus.SabreCSG
             if (e.type == EventType.MouseUp || e.rawType == EventType.MouseUp)
             {
                 moveInProgress = false;
+            }
+
+            if (e.type == EventType.KeyDown || e.type == EventType.KeyUp)
+            {
+                OnKeyAction(sceneView, e);
             }
 
             if (primaryTargetBrush != null && AnySelected)
@@ -963,7 +970,22 @@ namespace Sabresaurus.SabreCSG
 			return refinedSelection;
 		}
 
-		public void OnRepaint (SceneView sceneView, Event e)
+        private void OnKeyAction(SceneView sceneView, Event e)
+        {
+            if (KeyMappings.EventsMatch(e, Event.KeyboardEvent(KeyMappings.Instance.SnapSelectionToCurrentGrid)))
+            {
+                if (e.type == EventType.KeyDown)
+                {
+                    inverseSnapSelectionToCurrentGridLogic = true;
+                }
+                else
+                {
+                    inverseSnapSelectionToCurrentGridLogic = false;
+                }
+            }
+        }
+
+        public void OnRepaint (SceneView sceneView, Event e)
 		{
 			if(isMarqueeSelection && sceneView == SceneView.lastActiveSceneView)
 			{

--- a/Scripts/Tools/VertexEditor.cs
+++ b/Scripts/Tools/VertexEditor.cs
@@ -336,6 +336,10 @@ namespace Sabresaurus.SabreCSG
 					brush.BreakTypeRelation();
 				}
 			}
+
+			if (CurrentSettings.PositionSnappingEnabled && CurrentSettings.SnapSelectionToCurrentGrid) {
+				SnapSelectedVertices(true);
+			}
 		}
 
 		public void SnapSelectedVertices(bool isAbsoluteGrid)

--- a/Scripts/UI/SabreCSGPreferences.cs
+++ b/Scripts/UI/SabreCSGPreferences.cs
@@ -13,7 +13,7 @@ namespace Sabresaurus.SabreCSG
     {
         private const string RUNTIME_CSG_DEFINE = "RUNTIME_CSG";
         private const string SABRE_CSG_DEBUG_DEFINE = "SABRE_CSG_DEBUG";
-        private static readonly Vector2 WINDOW_SIZE = new Vector2(370, 400);
+        private static readonly Vector2 WINDOW_SIZE = new Vector2(370, 450);
 
         //private static Event cachedEvent;
 
@@ -66,6 +66,9 @@ namespace Sabresaurus.SabreCSG
                 SceneView.RepaintAll();
                 CurrentSettings.HideGridInPerspective = newHideGridInPerspective;
             }
+            
+            EditorGUILayout.HelpBox("When position snapping is enabled, you can press y to snap movement to the current grid size or tick this option to have it always on.", MessageType.Info);
+            CurrentSettings.AlwaysSnapToCurrentGrid = GUILayout.Toggle(CurrentSettings.AlwaysSnapToCurrentGrid, "Always snap to current grid size");
 
             CurrentSettings.OverrideFlyCamera = GUILayout.Toggle(CurrentSettings.OverrideFlyCamera, "Linear fly camera");
 

--- a/Scripts/UI/SabreCSGPreferences.cs
+++ b/Scripts/UI/SabreCSGPreferences.cs
@@ -13,7 +13,7 @@ namespace Sabresaurus.SabreCSG
     {
         private const string RUNTIME_CSG_DEFINE = "RUNTIME_CSG";
         private const string SABRE_CSG_DEBUG_DEFINE = "SABRE_CSG_DEBUG";
-        private static readonly Vector2 WINDOW_SIZE = new Vector2(370, 450);
+        private static readonly Vector2 WINDOW_SIZE = new Vector2(370, 430);
 
         //private static Event cachedEvent;
 
@@ -67,8 +67,7 @@ namespace Sabresaurus.SabreCSG
                 CurrentSettings.HideGridInPerspective = newHideGridInPerspective;
             }
             
-            EditorGUILayout.HelpBox("When position snapping is enabled, you can press y to snap movement to the current grid size or tick this option to have it always on.", MessageType.Info);
-            CurrentSettings.AlwaysSnapToCurrentGrid = GUILayout.Toggle(CurrentSettings.AlwaysSnapToCurrentGrid, "Always snap to current grid size");
+            CurrentSettings.AlwaysSnapToCurrentGrid = GUILayout.Toggle(CurrentSettings.AlwaysSnapToCurrentGrid, new GUIContent("Always snap to current grid size", "When position snapping is enabled, you can press " + KeyMappings.Instance.SnapSelectionToCurrentGrid + " to snap movement to the current grid size or tick this option to have it always on."));
 
             CurrentSettings.OverrideFlyCamera = GUILayout.Toggle(CurrentSettings.OverrideFlyCamera, "Linear fly camera");
 


### PR DESCRIPTION
Hello. Here's the pull request I've been threatening Henry with.
It deals with an alternative way of grid snapping.
Specifically when snapping from a smaller to a larger grid.
This is the vanilla snapping behaviour. I got a brush aligned to a 0.5 unit grid
and move it on 1 unit grid.
![Vanilla Snap](https://i.imgur.com/xsFMGm6.gif)

The changes will take such offset into account and cause the moved bits to snap to
the current grid size instead:
![Modified Snap](https://i.imgur.com/6wliVfw.gif)

It does that by finding the side or corner of the selections bounds that is moved,
snap its position to the current grid and apply the delta between real position and snapped position to the translation delta which is passed into RescaleBrush and TranslateBrush.

To make the behaviour even I've also added an additional snapping step when moving vertices with the vertex tool


This new movement can be activated by pressing and holding the Y button.
Alternatively, I've added a toggle in the preferences to have this behaviour always on.
That is off by default.

It will also only take effect when position snapping is enabled.


Lastly I want to say, this snapping behaviour is much closer to tools like Hammer or the Sledge editor
and should make it easier for newcomers, like me, to get around Sabre as to them,
the vanilla snapping might be hard to wrap their heads around.
Which is the mai reason I've made a preference option to have it always on.
It's something, when you know it and love it, don't want to have to keep pressing a modifier key for.
But of course, if you don't you don't always want it.
As such I think this is a way to have the good stuff of both sides.