### PR TITLE
Try to fix Subtractive brush corruptions in Optimize Geometry

### DIFF
--- a/Scripts/Core/BuildEngine/Optimizer.cs
+++ b/Scripts/Core/BuildEngine/Optimizer.cs
@@ -132,13 +132,24 @@ namespace Sabresaurus.SabreCSG
 		/// <param name="polygons">Coplanar set of polygons.</param>
 		internal static List<Polygon> CalculateConvexHulls(List<Polygon> polygons)
         {
-			// Convex hull of 1 polygon is guaranteed to be itself, so early out. Note that care must be taken as the reference is the same as the input
+            // Convex hull of 1 polygon is guaranteed to be itself, so early out. Note that care must be taken as the reference is the same as the input
             //if(polygons.Count == 1)
             //{
             //    return polygons;
             //}
 
-			// Cache the polygon's normal so that we don't have to calculate it for the new polygons
+            //Coplanar test. If failed, abort optimization;
+            for (int i = 0; i < polygons.Count; i++)
+            {
+                for (int j = i + 1; j < polygons.Count; j++)
+                {
+                    if (!MathHelper.PlaneEqualsLooser(polygons[i].Plane, polygons[j].Plane))
+                    {
+                        return polygons;
+                    }
+                }
+            }
+            // Cache the polygon's normal so that we don't have to calculate it for the new polygons
             Vector3 normal = polygons[0].Plane.normal;
 
             // TODO: Generate islands

--- a/Scripts/Core/BuildEngine/TriangulationNode.cs
+++ b/Scripts/Core/BuildEngine/TriangulationNode.cs
@@ -17,39 +17,66 @@ namespace Sabresaurus.SabreCSG
 
 		internal TriangulationNode(List<Polygon> polygonsToProcess, List<SimpleEdge> edges)
 		{
-			for (int i = 0; i < edges.Count; i++)
+            List<Polygon> LastPolygonsFront=null;
+            List<Polygon> LastPolygonsBack = null;
+            List<SimpleEdge> LastFrontEdges = null;
+            List<SimpleEdge> LastBackEdges = null;
+            bool hasFound = false;
+            for (int i = 0; i < edges.Count; i++)
 			{
 				List<Polygon> polygonsFront;
 				List<Polygon> polygonsBack;
-				if (PolygonFactory.SplitCoplanarPolygonsByPlane(polygonsToProcess, edges[i].Plane, out polygonsFront, out polygonsBack))
+                
+                if (PolygonFactory.SplitCoplanarPolygonsByPlane(polygonsToProcess, edges[i].Plane, out polygonsFront, out polygonsBack))
 				{
 					// Split success
 //					activePlane = planes[i];
-
+    
 					List<SimpleEdge> frontEdges = new List<SimpleEdge>();
 					List<SimpleEdge> backEdges = new List<SimpleEdge>();
-
-					for (int j = i+1; j < edges.Count; j++) 
+                    bool cutedge = false;
+                    
+					for (int j = 0; j < edges.Count; j++) 
 					{
+                        if (i == j) continue;
 //						Vector3 point = planes[j].normal * planes[j].distance;
-						Vector3 point = edges[j].MidPoint;
-						int side = MathHelper.GetSideThick(edges[i].Plane, point);
-                        if (side == -1)
+                        //when you cut through an edge, by checking midpoint you will put the edge in one side while it should be in both side
+                        //So we should check both endpoint instead
+						Vector3 point1 = edges[j].Position1;
+                        Vector3 point2 = edges[j].Position2;
+                        int side1 = MathHelper.GetSideThick(edges[i].Plane, point1);
+                        int side2 = MathHelper.GetSideThick(edges[i].Plane, point2);
+                        if (side1 * side2 >= 0)
                         {
-                            frontEdges.Add(edges[j]);
-                        }
-                        else if (side == 1)
-                        {
-                            backEdges.Add(edges[j]);
+                            if (side1 + side2 < 0)
+                            {
+                                frontEdges.Add(edges[j]);
+                            }
+                            else
+                            {
+                                backEdges.Add(edges[j]);
+                            }
                         }
                         else
                         {
+                            cutedge = true;
                             frontEdges.Add(edges[j]);
                             backEdges.Add(edges[j]);
                         }
                     }
-
-					front = new TriangulationNode(polygonsFront, frontEdges);
+                    //don't early out when we cut through an edge, we will find a better cut
+                    if (cutedge) {
+                        hasFound = true;
+                        //Debug.DrawLine(edges[i].Position1, edges[i].Position2, Color.red, 300, false);
+                        LastPolygonsFront = polygonsFront;
+                        LastPolygonsBack = polygonsBack;
+                        LastFrontEdges = frontEdges;
+                        LastBackEdges =backEdges;
+                        continue;
+                    }
+                    //if(hasFound) Debug.DrawLine(edges[i].Position1, edges[i].Position2, Color.green, 300, false);
+                    //else Debug.DrawLine(edges[i].Position1, edges[i].Position2, Color.blue, 300, false);
+                    front = new TriangulationNode(polygonsFront, frontEdges);
 					back = new TriangulationNode(polygonsBack, backEdges);
 
 //					Debug.Log(planes[i].ToStringLong() + " " + polygonsFront.Count + " " + polygonsBack.Count);
@@ -58,7 +85,13 @@ namespace Sabresaurus.SabreCSG
 					return;
 				}
 			}
-
+            //Fallback if we haven't found a better one
+            if (hasFound)
+            {
+                front = new TriangulationNode(LastPolygonsFront, LastFrontEdges);
+                back = new TriangulationNode(LastPolygonsBack, LastBackEdges);
+                return;
+            }
 			this.polygonsAtNode = polygonsToProcess;
 		}
 


### PR DESCRIPTION
Tried to fix the bug in #103 
I found two bugs that may cause Subtractive brush corruptions in Optimize Geometry.
First, in TriangulationNode, an edge is divided into frontEdges and backEdges by its midpoint. This is wrong when you cut through an edge of a hole. As a result the hole edge only ends up in one side, so the other side will ingore the hole. I changed it by comparing two endpoints to fix this problem. Also add a condition to not early out in order to get better cuts.
Second, the polygons in a group is not always coplanar. This may be caused by some bugs in the core algorithm, and I can't fix it. But I added a coplanar test in CalculateConvexHulls to skip the optimization of corrupted polygon groups.

The effect is shown below:
Optimize Geometry Off:
![origin](https://user-images.githubusercontent.com/46198159/50508189-c44c2f00-0abb-11e9-9dce-e30f356a0598.png)
Before fix, Optimize Geometry On: the hole below get corrupted
![before](https://user-images.githubusercontent.com/46198159/50508201-d6c66880-0abb-11e9-9055-10d7af5f0b92.png)
After my fix, Optimize Geometry On: No More Corruptions!
![after](https://user-images.githubusercontent.com/46198159/50508279-29078980-0abc-11e9-8995-6c7b525f0470.png)
