### PR TITLE
Toolbar compound brush menu threw OutOfRangeException.

### DIFF
--- a/Scripts/UI/Toolbar.cs
+++ b/Scripts/UI/Toolbar.cs
@@ -494,11 +494,12 @@ namespace Sabresaurus.SabreCSG
 				List<Type> compoundBrushTypes = CompoundBrush.FindAllInAssembly();
 				for (int i = 0; i < compoundBrushTypes.Count; i++) 
 				{
+                    int j = i; // Unity IL bug causes "i" to be "2" in the lambda expression unless we assign it to a scoped variable.
 					menu.AddItem (
 						new GUIContent (compoundBrushTypes[i].Name), 
 						false, 
 						() => {
-							CreateCompoundBrush(compoundBrushTypes[i]);
+							CreateCompoundBrush(compoundBrushTypes[j]);
 							primitiveMenuShowing = false;
 						} 
 					);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7905726/51101272-420d7b80-17da-11e9-811d-47c505b7d85a.png)
It seems this anonymous lambda method will use the latest value of i which is 2 as the loop ended, not the current value at the time of the iteration.

![image](https://user-images.githubusercontent.com/7905726/51101285-50f42e00-17da-11e9-8ac4-8f30caacaa68.png)
It appears to be a Unity IL bug that causes "i" to be "2" in the lambda expression unless we assign it to a scoped variable.