### PR TITLE
Fix build error when build inside prefab instance

### DIFF
--- a/Scripts/Core/BuildEngine/MeshGroupManager.cs
+++ b/Scripts/Core/BuildEngine/MeshGroupManager.cs
@@ -29,7 +29,18 @@ namespace Sabresaurus.SabreCSG
 #if UNITY_EDITOR
                 if (filters[i].sharedMesh != null && !UnityEditor.AssetDatabase.Contains(filters[i].sharedMesh))
 #endif
-                    GameObject.DestroyImmediate(filters[i].sharedMesh);
+                {
+#if UNITY_EDITOR && UNITY_2018_3_OR_NEWER
+                    if (UnityEditor.PrefabUtility.IsPartOfPrefabInstance(filters[i].sharedMesh))
+                    {
+                        GameObject.DestroyImmediate(UnityEditor.PrefabUtility.GetCorrespondingObjectFromOriginalSource(filters[i].sharedMesh));
+                    }
+                    else
+#endif
+                    {
+                        GameObject.DestroyImmediate(filters[i].sharedMesh);
+                    }
+                }
             }
 
             for (int i = 0; i < colliders.Length; i++)
@@ -37,7 +48,18 @@ namespace Sabresaurus.SabreCSG
 #if UNITY_EDITOR
                 if (colliders[i].sharedMesh != null && !UnityEditor.AssetDatabase.Contains(colliders[i].sharedMesh))
 #endif
-                    GameObject.DestroyImmediate(colliders[i].sharedMesh);
+                {
+#if UNITY_EDITOR && UNITY_2018_3_OR_NEWER
+                    if (UnityEditor.PrefabUtility.IsPartOfPrefabInstance(colliders[i].sharedMesh))
+                    {
+                        GameObject.DestroyImmediate(UnityEditor.PrefabUtility.GetCorrespondingObjectFromOriginalSource(colliders[i].sharedMesh));
+                    }
+                    else
+#endif
+                    {
+                        GameObject.DestroyImmediate(colliders[i].sharedMesh);
+                    }
+                }
             }
 
             // Finally destroy the game objects and components

--- a/Scripts/Extensions/Extensions.cs
+++ b/Scripts/Extensions/Extensions.cs
@@ -184,7 +184,17 @@ namespace Sabresaurus.SabreCSG
             int childCount = parentTransform.childCount;
             for (int i = 0; i < childCount; i++)
             {
-                GameObject.DestroyImmediate(parentTransform.GetChild(0).gameObject);
+                var go = parentTransform.GetChild(0).gameObject;
+#if UNITY_EDITOR && UNITY_2018_3_OR_NEWER
+                if (UnityEditor.PrefabUtility.IsPartOfPrefabInstance(go))
+                {
+                    GameObject.DestroyImmediate(UnityEditor.PrefabUtility.GetCorrespondingObjectFromOriginalSource(go), true);
+                }
+                else
+#endif
+                {
+                    GameObject.DestroyImmediate(go);
+                }
 
                 //			GameObject.DestroyImmediate(parentTransform.GetChild(i).gameObject);
             }


### PR DESCRIPTION
# Description
With Unity 2018.3's nested prefab feature, rebuilding inside prefab instance doesn't work properly.
Because we can't remove gameobjects(meshes) inside a prefab instance by design.
So, I fix this by removing gameobjects from original prefab, not from prefab instance.

We may create new gameobjects in the original prefab, too.
But creating them in a prefab instance isn't prohibited, so I leave this unchanged.
Because of this, you should apply prefab changes manually after rebuild.

# Comparison (sorry for version inconsistency)

## Before
![honeycam 2019-02-01 16-50-13](https://user-images.githubusercontent.com/1144460/52109649-8f467580-2641-11e9-8ae2-411786312871.gif)

## After
![honeycam 2019-02-01 16-52-34](https://user-images.githubusercontent.com/1144460/52109716-cae13f80-2641-11e9-8446-76fc10fbf98f.gif)

