### PR TITLE
Cleanup and Unity 5 fixes for merged PRs.

### DIFF
--- a/Scripts/Tools/ResizeEditor.cs
+++ b/Scripts/Tools/ResizeEditor.cs
@@ -1397,8 +1397,6 @@ namespace Sabresaurus.SabreCSG
 			bool[] collisionStates = targetBrushBases.Select(item => item.HasCollision).Distinct().ToArray();
 			bool hasCollision = (collisionStates.Length == 1) ? collisionStates[0] : false;
 
-			GUIStyle toggleStyle = new GUIStyle(GUI.skin.toggle);
-
 			// TODO: If the brushes are all volumes, the collision and visible checkboxes should be disabled
 
 			// bool allVolumes = true;
@@ -1453,7 +1451,6 @@ namespace Sabresaurus.SabreCSG
 			GUILayout.Label("Flip", EditorStyles.label);
 			GUILayout.FlexibleSpace();
 
-			string[] flipToolbarStrings = {"X","Y","Z"};
 			int flipIndex = -1;
             if(GUILayout.Button("X", EditorStyles.miniButtonLeft, GUILayout.Width(20)))
             {

--- a/Scripts/UI/SabreCSGPreferences.cs
+++ b/Scripts/UI/SabreCSGPreferences.cs
@@ -91,7 +91,7 @@ namespace Sabresaurus.SabreCSG
             CurrentSettings.OverrideFlyCamera = GUILayout.Toggle(CurrentSettings.OverrideFlyCamera, "Linear fly camera");
 
             EditorGUILayout.Space();
-            using (new EditorGUI.IndentLevelScope()) {
+            using (new SabreEditorGUI.IndentLevelScope()) {
                 EditorGUILayout.LabelField("Experimental Options", EditorStyles.boldLabel);
             }
             EditorGUILayout.Space();
@@ -99,7 +99,7 @@ namespace Sabresaurus.SabreCSG
             CurrentSettings.VertexPaintToolEnabled = GUILayout.Toggle(CurrentSettings.VertexPaintToolEnabled, "Vertex paint tool");
 
             EditorGUILayout.Space();
-            using (new EditorGUI.IndentLevelScope()) {
+            using (new SabreEditorGUI.IndentLevelScope()) {
                 EditorGUILayout.LabelField("Developer Options", EditorStyles.boldLabel);
             }
             EditorGUILayout.Space();

--- a/Scripts/UI/SabreEditorGUI.cs
+++ b/Scripts/UI/SabreEditorGUI.cs
@@ -1,0 +1,38 @@
+﻿#if UNITY_EDITOR
+
+using UnityEditor;
+
+namespace Sabresaurus.SabreCSG
+{
+    public class SabreEditorGUI
+    {
+#if UNITY_5
+
+        /// <summary>
+        /// Scope for managing the indent level of the field labels.
+        /// </summary>
+        public class IndentLevelScope : System.IDisposable
+        {
+            public IndentLevelScope()
+            {
+                EditorGUI.indentLevel++;
+            }
+
+            public void Dispose()
+            {
+                EditorGUI.indentLevel--;
+            }
+        }
+
+#else
+
+        /// <summary>
+        /// Scope for managing the indent level of the field labels.
+        /// </summary>
+        public class IndentLevelScope : EditorGUI.IndentLevelScope { }
+
+#endif
+    }
+}
+
+#endif

--- a/Scripts/UI/SabreEditorGUI.cs.meta
+++ b/Scripts/UI/SabreEditorGUI.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 78704bfb5cc5e67448aa830cbd12f223
+timeCreated: 1549040169
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/UI/Toolbar.cs
+++ b/Scripts/UI/Toolbar.cs
@@ -18,12 +18,6 @@ namespace Sabresaurus.SabreCSG
 
 		public static int bottomToolbarHeight;
 
-		static string[] gridTypeSettings = new string[] {
-			"Unity",
-			"SabreCSG",
-			"None"
-		};
-
         static CSGModel csgModel;
 
 		static string warningMessage = "Concave brushes detected";


### PR DESCRIPTION
- Fixed several unused variable warnings.
- Fixed compilation errors in Unity 5 by creating a `SabreEditorGUI.IndentLevelScope` with fallback solution for Unity 5.