### PR TITLE
Fixed parsing errors in map importers due to OS language.

### DIFF
--- a/Scripts/Importers/Quake1/MapImporter.cs
+++ b/Scripts/Importers/Quake1/MapImporter.cs
@@ -1,6 +1,7 @@
 ﻿#if UNITY_EDITOR || RUNTIME_CSG
 
 using System;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 
@@ -151,14 +152,14 @@ namespace Sabresaurus.SabreCSG.Importers.Quake1
 
                 try
                 {
-                    MapVector3 p1 = new MapVector3(float.Parse(values[0]), float.Parse(values[1]), float.Parse(values[2]));
-                    MapVector3 p2 = new MapVector3(float.Parse(values[3]), float.Parse(values[4]), float.Parse(values[5]));
-                    MapVector3 p3 = new MapVector3(float.Parse(values[6]), float.Parse(values[7]), float.Parse(values[8]));
+                    MapVector3 p1 = new MapVector3(float.Parse(values[0], CultureInfo.InvariantCulture), float.Parse(values[1], CultureInfo.InvariantCulture), float.Parse(values[2], CultureInfo.InvariantCulture));
+                    MapVector3 p2 = new MapVector3(float.Parse(values[3], CultureInfo.InvariantCulture), float.Parse(values[4], CultureInfo.InvariantCulture), float.Parse(values[5], CultureInfo.InvariantCulture));
+                    MapVector3 p3 = new MapVector3(float.Parse(values[6], CultureInfo.InvariantCulture), float.Parse(values[7], CultureInfo.InvariantCulture), float.Parse(values[8], CultureInfo.InvariantCulture));
                     mapBrushSide.Plane = new MapPlane(p1, p2, p3);
                     mapBrushSide.Material = values[9];
-                    mapBrushSide.Offset = new MapVector2(float.Parse(values[10]), float.Parse(values[11]));
-                    mapBrushSide.Rotation = float.Parse(values[12]);
-                    mapBrushSide.Scale = new MapVector2(float.Parse(values[13]), float.Parse(values[14]));
+                    mapBrushSide.Offset = new MapVector2(float.Parse(values[10], CultureInfo.InvariantCulture), float.Parse(values[11], CultureInfo.InvariantCulture));
+                    mapBrushSide.Rotation = float.Parse(values[12], CultureInfo.InvariantCulture);
+                    mapBrushSide.Scale = new MapVector2(float.Parse(values[13], CultureInfo.InvariantCulture), float.Parse(values[14], CultureInfo.InvariantCulture));
                 }
                 catch (Exception)
                 {

--- a/Scripts/Importers/UnrealGold/T3dImporter.cs
+++ b/Scripts/Importers/UnrealGold/T3dImporter.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -166,7 +167,7 @@ namespace Sabresaurus.SabreCSG.Importers.UnrealGold
         {
             // remove the first word, any +123 values and trim spaces.
             string[] parts = line.Substring(line.IndexOf(' ')).Replace("+", "").Trim().Split(',');
-            return new T3dVector3(float.Parse(parts[0]), float.Parse(parts[1]), float.Parse(parts[2]));
+            return new T3dVector3(float.Parse(parts[0], CultureInfo.InvariantCulture), float.Parse(parts[1], CultureInfo.InvariantCulture), float.Parse(parts[2], CultureInfo.InvariantCulture));
         }
 
         /// <summary>

--- a/Scripts/Importers/ValveMapFormat2006/VmfImporter.cs
+++ b/Scripts/Importers/ValveMapFormat2006/VmfImporter.cs
@@ -1,6 +1,7 @@
 ﻿#if UNITY_EDITOR || RUNTIME_CSG
 
 using System;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 
@@ -254,9 +255,9 @@ namespace Sabresaurus.SabreCSG.Importers.ValveMapFormat2006
             if (rawvalue[0] == '(')
             {
                 string[] values = rawvalue.Replace("(", "").Replace(")", "").Split(' ');
-                VmfVector3 p1 = new VmfVector3(float.Parse(values[0]), float.Parse(values[1]), float.Parse(values[2]));
-                VmfVector3 p2 = new VmfVector3(float.Parse(values[3]), float.Parse(values[4]), float.Parse(values[5]));
-                VmfVector3 p3 = new VmfVector3(float.Parse(values[6]), float.Parse(values[7]), float.Parse(values[8]));
+                VmfVector3 p1 = new VmfVector3(float.Parse(values[0], CultureInfo.InvariantCulture), float.Parse(values[1], CultureInfo.InvariantCulture), float.Parse(values[2], CultureInfo.InvariantCulture));
+                VmfVector3 p2 = new VmfVector3(float.Parse(values[3], CultureInfo.InvariantCulture), float.Parse(values[4], CultureInfo.InvariantCulture), float.Parse(values[5], CultureInfo.InvariantCulture));
+                VmfVector3 p3 = new VmfVector3(float.Parse(values[6], CultureInfo.InvariantCulture), float.Parse(values[7], CultureInfo.InvariantCulture), float.Parse(values[8], CultureInfo.InvariantCulture));
                 value = new VmfPlane(p1, p2, p3);
                 return true;
             }
@@ -264,7 +265,7 @@ namespace Sabresaurus.SabreCSG.Importers.ValveMapFormat2006
             else if (rawvalue[0] == '[')
             {
                 string[] values = rawvalue.Replace("[", "").Replace("]", "").Split(' ');
-                value = new VmfAxis(new VmfVector3(float.Parse(values[0]), float.Parse(values[1]), float.Parse(values[2])), float.Parse(values[3]), float.Parse(values[4]));
+                value = new VmfAxis(new VmfVector3(float.Parse(values[0], CultureInfo.InvariantCulture), float.Parse(values[1], CultureInfo.InvariantCulture), float.Parse(values[2], CultureInfo.InvariantCulture)), float.Parse(values[3], CultureInfo.InvariantCulture), float.Parse(values[4], CultureInfo.InvariantCulture));
                 return true;
             }
             // detect floating point value.


### PR DESCRIPTION
The `float.Parse(x)` methods required `CultureInfo.InvariantCulture` as the second argument to make them work on operating systems where the region settings are `1,234.56` instead of `1.234,56` i.e. the comma is the separator instead of a period.