### PR TITLE
Fixed to work with Unity 2019.2.5

### DIFF
--- a/Scripts/Compatibility/Editor/UnityEventDrawer.cs
+++ b/Scripts/Compatibility/Editor/UnityEventDrawer.cs
@@ -418,7 +418,7 @@ namespace UnityEditorInternal
         static UnityEventBase GetDummyEvent(SerializedProperty prop)
         {
             // Create dummy instance of this type... we need it for function validation ect
-            var typeName = prop.FindPropertyRelative("m_TypeName").stringValue;
+            var typeName = prop.type;
             Type type = Type.GetType(typeName, false);
             if (type == null)
                 return new UnityEvent();


### PR DESCRIPTION
The UI for `UnityEvent`s always appeared missing, it's fixed now. 

Thanks for the amazing tool SabreCSG is.