### PR TITLE
Fixed Unity 2019 having no GUI among other issues.

### DIFF
--- a/Scripts/CSGModel.cs
+++ b/Scripts/CSGModel.cs
@@ -1345,7 +1345,11 @@ namespace Sabresaurus.SabreCSG
             if (!EditorHelper.SceneViewHasDelegate(OnSceneGUI))
             {
                 // Then resubscribe and repaint
+#if UNITY_2019_1_OR_NEWER
+                SceneView.duringSceneGui += OnSceneGUI;
+#else
                 SceneView.onSceneGUIDelegate += OnSceneGUI;
+#endif
                 SceneView.RepaintAll();
             }
 

--- a/Scripts/CSGModel.cs
+++ b/Scripts/CSGModel.cs
@@ -1429,7 +1429,11 @@ namespace Sabresaurus.SabreCSG
             EditorApplication.update -= OnEditorUpdate;
             EditorApplication.hierarchyWindowItemOnGUI -= OnHierarchyItemGUI;
             EditorApplication.projectWindowItemOnGUI -= OnProjectItemGUI;
+#if UNITY_2019_1_OR_NEWER
+            SceneView.duringSceneGui -= OnSceneGUI;
+#else
             SceneView.onSceneGUIDelegate -= OnSceneGUI;
+#endif
             Undo.undoRedoPerformed -= OnUndoRedoPerformed;
 
             GridManager.UpdateGrid();
@@ -1438,8 +1442,13 @@ namespace Sabresaurus.SabreCSG
         public void RebindToOnSceneGUI()
         {
             // Unbind the delegate, then rebind to ensure our method gets called last
+#if UNITY_2019_1_OR_NEWER
+            SceneView.duringSceneGui -= OnSceneGUI;
+            SceneView.duringSceneGui += OnSceneGUI;
+#else
             SceneView.onSceneGUIDelegate -= OnSceneGUI;
             SceneView.onSceneGUIDelegate += OnSceneGUI;
+#endif
         }
 
         public void ExportOBJ(bool limitToSelection)
@@ -2045,7 +2054,11 @@ namespace Sabresaurus.SabreCSG
             if (buildSettings.GenerateLightmapUVs)
             {
                 UnityEditor.StaticEditorFlags staticFlags = UnityEditor.GameObjectUtility.GetStaticEditorFlags(newGameObject);
+#if UNITY_2019_1_OR_NEWER
+                staticFlags |= UnityEditor.StaticEditorFlags.ContributeGI;
+#else
                 staticFlags |= UnityEditor.StaticEditorFlags.LightmapStatic;
+#endif
                 UnityEditor.GameObjectUtility.SetStaticEditorFlags(newGameObject, staticFlags);
             }
         }
@@ -2117,7 +2130,7 @@ namespace Sabresaurus.SabreCSG
 		}
 #endif
 #endif
+            }
     }
-}
 
 #endif

--- a/Scripts/CSGModel.cs
+++ b/Scripts/CSGModel.cs
@@ -1334,6 +1334,7 @@ namespace Sabresaurus.SabreCSG
         /// Used to determined whether we are subscribed to the "During scene GUI" event.
         /// Recompilations will reset this variable to false and we can rebind.
         /// </summary>
+        [NonSerialized]
         private bool isSubscribedToDuringSceneGui = false;
 
         protected override void Update()

--- a/Scripts/CSGModel.cs
+++ b/Scripts/CSGModel.cs
@@ -1330,6 +1330,12 @@ namespace Sabresaurus.SabreCSG
             }
         }
 
+        /// <summary>
+        /// Used to determined whether we are subscribed to the "During scene GUI" event.
+        /// Recompilations will reset this variable to false and we can rebind.
+        /// </summary>
+        private bool isSubscribedToDuringSceneGui = false;
+
         protected override void Update()
         {
             if (editMode && !anyCSGModelsInEditMode)
@@ -1342,9 +1348,10 @@ namespace Sabresaurus.SabreCSG
 
             // Make sure the events we need to listen for are all bound (recompilation removes listeners, so it is
             // necessary to rebind dynamically)
-            if (!EditorHelper.SceneViewHasDelegate(OnSceneGUI))
+            if (!isSubscribedToDuringSceneGui)
             {
                 // Then resubscribe and repaint
+                isSubscribedToDuringSceneGui = true;
 #if UNITY_2019_1_OR_NEWER
                 SceneView.duringSceneGui += OnSceneGUI;
 #else

--- a/Scripts/Compatibility/Editor/UnityEventDrawer.cs
+++ b/Scripts/Compatibility/Editor/UnityEventDrawer.cs
@@ -1,4 +1,4 @@
-﻿#if !UNITY_2018_OR_NEWER
+﻿#if !UNITY_2018_1_OR_NEWER
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Scripts/Editor/Utilities/UtilityShortcuts.cs
+++ b/Scripts/Editor/Utilities/UtilityShortcuts.cs
@@ -98,16 +98,28 @@ namespace Sabresaurus.SabreCSG
 				if(EditorHelper.GetSceneViewCamera(sceneView) == EditorHelper.SceneViewCamera.Other)
 				{
 					sceneView.orthographic = false;
-					sceneView.m_SceneLighting = true;
-				}
-				else
+#if UNITY_2019_1_OR_NEWER
+                    sceneView.sceneLighting = true;
+#else
+                    sceneView.m_SceneLighting = true;
+#endif
+                }
+                else
 				{
 					sceneView.orthographic = true;
-					sceneView.m_SceneLighting = false;
-					SceneView.SceneViewState state = GetSceneViewState(sceneView);
-					state.Toggle(false);
-				}
-			}
+#if UNITY_2019_1_OR_NEWER
+                    sceneView.sceneLighting = false;
+#else
+                    sceneView.m_SceneLighting = false;
+#endif
+                    SceneView.SceneViewState state = GetSceneViewState(sceneView);
+#if UNITY_2019_1_OR_NEWER
+                    state.SetAllEnabled(false);
+#else
+                    state.Toggle(false);
+#endif
+                }
+            }
 			SceneView.RepaintAll();
 		}
 

--- a/Scripts/Extensions/EditorHelper.cs
+++ b/Scripts/Extensions/EditorHelper.cs
@@ -41,12 +41,15 @@ namespace Sabresaurus.SabreCSG
 			}
 		}
 
-	    public static bool SceneViewHasDelegate(SceneView.OnSceneFunc targetDelegate)
-	    {
-			return HasDelegate(SceneView.onSceneGUIDelegate, targetDelegate);
-	    }
+        /// <summary>
+        /// DO NOT USE - only here for compatibility with old third party plugins!
+        /// </summary>
+        public static bool SceneViewHasDelegate(SceneView.OnSceneFunc targetDelegate)
+        {
+            return HasDelegate(SceneView.onSceneGUIDelegate, targetDelegate);
+        }
 
-	    public enum SceneViewCamera { Top, Bottom, Left, Right, Front, Back, Other };
+        public enum SceneViewCamera { Top, Bottom, Left, Right, Front, Back, Other };
 
 		public static SceneViewCamera GetSceneViewCamera(SceneView sceneView)
 		{

--- a/Scripts/UI/CSGGrid.cs
+++ b/Scripts/UI/CSGGrid.cs
@@ -16,17 +16,16 @@ namespace Sabresaurus.SabreCSG
 		const float MAJOR_LINE_DISTANCE = 200;
 		const float MINOR_LINE_DISTANCE = 50;
 
-		public static void Activate()
+        public static void Activate()
 		{
-			if(!EditorHelper.SceneViewHasDelegate(OnSceneGUI))
-			{
-                // Then resubscribe and repaint
+            // resubscribe to the scene GUI updates.
 #if UNITY_2019_1_OR_NEWER
-                SceneView.duringSceneGui += OnSceneGUI;
+            SceneView.duringSceneGui -= OnSceneGUI;
+            SceneView.duringSceneGui += OnSceneGUI;
 #else
-                SceneView.onSceneGUIDelegate += OnSceneGUI;
+            SceneView.onSceneGUIDelegate -= OnSceneGUI;
+            SceneView.onSceneGUIDelegate += OnSceneGUI;
 #endif
-            }
 
             CSGModel[] csgModels = Object.FindObjectsOfType<CSGModel>();
 

--- a/Scripts/UI/CSGGrid.cs
+++ b/Scripts/UI/CSGGrid.cs
@@ -20,11 +20,15 @@ namespace Sabresaurus.SabreCSG
 		{
 			if(!EditorHelper.SceneViewHasDelegate(OnSceneGUI))
 			{
-				// Then resubscribe and repaint
-				SceneView.onSceneGUIDelegate += OnSceneGUI;
-			}
+                // Then resubscribe and repaint
+#if UNITY_2019_1_OR_NEWER
+                SceneView.duringSceneGui += OnSceneGUI;
+#else
+                SceneView.onSceneGUIDelegate += OnSceneGUI;
+#endif
+            }
 
-			CSGModel[] csgModels = Object.FindObjectsOfType<CSGModel>();
+            CSGModel[] csgModels = Object.FindObjectsOfType<CSGModel>();
 
 			// Make sure the grid draws behind the CSG Model drawing. This requires us to ask the CSG Model to reregister
 			for (int i = 0; i < csgModels.Length; i++) 
@@ -39,10 +43,14 @@ namespace Sabresaurus.SabreCSG
 
 		public static void Deactivate()
 		{
-			SceneView.onSceneGUIDelegate -= OnSceneGUI;
-		}
+#if UNITY_2019_1_OR_NEWER
+            SceneView.duringSceneGui -= OnSceneGUI;
+#else
+            SceneView.onSceneGUIDelegate -= OnSceneGUI;
+#endif
+        }
 
-		static void OnSceneGUI(SceneView sceneView)
+        static void OnSceneGUI(SceneView sceneView)
 		{
 			Event e = Event.current;
 


### PR DESCRIPTION
This commit fixes #234 and #233 and provides complete Unity 2019 support.

- The `!UNITY_2018_OR_NEWER` was replaced by `!UNITY_2018_1_OR_NEWER` that 2019 recognizes properly.
- `SceneView.onSceneGUIDelegate` has been replaced by `SceneView.duringSceneGui`.
- `UnityEditor.StaticEditorFlags.LightmapStatic` has been replaced by `UnityEditor.StaticEditorFlags.ContributeGI`.
- `sceneView.m_SceneLighting` has been replaced by `sceneView.sceneLighting`.
- `SceneView.SceneViewState.Toggle` has been replaced by `SceneView.SceneViewState.SetAllEnabled`.

`EditorHelper.SceneViewHasDelegate` has been deprecated. `SceneView.duringSceneGui` is an event and C# enforces that it can only be mentioned in conjunction with a += or -= operator. In order to determine whether we are already subscribed I decided to create a boolean with the [NonSerialized] flag to ensure that any script recompilations will reset it.

Essentially this:

```csharp
/// <summary>
/// Used to determined whether we are subscribed to the "During scene GUI" event.
/// Recompilations will reset this variable to false and we can rebind.
/// </summary>
[NonSerialized]
private bool isSubscribedToDuringSceneGui = false;

if (!isSubscribedToDuringSceneGui)
{
    // Then resubscribe and repaint
    isSubscribedToDuringSceneGui = true;
    SceneView.duringSceneGui += OnSceneGUI;
    SceneView.RepaintAll();
}
```

I tested this new code on Unity 5.3, 2017, 2018 and 2019. Works perfectly.