### PR TITLE
Fixed invisible chamfer popup window.

### DIFF
--- a/Scripts/Tools/ToolSettingsPopup.cs
+++ b/Scripts/Tools/ToolSettingsPopup.cs
@@ -46,7 +46,7 @@ namespace Sabresaurus.SabreCSG
         /// <summary>
         /// The height of the popup window.
         /// </summary>
-        private float m_Height = 0.0f;
+        private float m_Height = 1.0f;
 
         /// <summary>
         /// The OnGUI action.


### PR DESCRIPTION
Fixes #226 where on Unity 2018 and 2019 the chamfer popup wouldn't appear. Thanks @AmitloafTotes!