### PR TITLE
Fixed #237. Vertex editor clipping after script recompilation.

### DIFF
--- a/Scripts/Tools/VertexEditor.cs
+++ b/Scripts/Tools/VertexEditor.cs
@@ -998,7 +998,7 @@ namespace Sabresaurus.SabreCSG
 			}
 
 			// Draw UI specific to this editor
-			Rect rectangle = new Rect(0, 50, 140, 180);
+			Rect rectangle = new Rect(0, 50, 175, 180);
 			GUIStyle toolbar = new GUIStyle(EditorStyles.toolbar);
 			toolbar.normal.background = SabreCSGResources.ClearTexture;
 			toolbar.fixedHeight = rectangle.height;


### PR DESCRIPTION
The vertex editor has had the wrong width for years. I don't know why Unity has always been able auto-correct it until my change in #235. It was originally 140px wide, 175px fixed it and windows snipping tool+mspaint (because that's how you measure things) confirmed the new size is right:

![image](https://user-images.githubusercontent.com/7905726/69669051-5fb19f80-1091-11ea-829d-c5dadb704cac.png)

Tested in 5.3, 2017, 2018 and 2019.