### PR TITLE
Fix access denied errors when importing maps

### DIFF
--- a/Scripts/Importers/Quake1/MapImporter.cs
+++ b/Scripts/Importers/Quake1/MapImporter.cs
@@ -25,7 +25,7 @@ namespace Sabresaurus.SabreCSG.Importers.Quake1
 
             // open the file for reading. we use streams for additional performance.
             // it's faster than File.ReadAllLines() as that requires two iterations.
-            using (FileStream stream = new FileStream(path, FileMode.Open))
+            using (FileStream stream = new FileStream(path, FileMode.Open, FileAccess.Read))
             using (StreamReader reader = new StreamReader(stream))
             {
                 // read all the lines from the file.

--- a/Scripts/Importers/UnrealGold/T3dImporter.cs
+++ b/Scripts/Importers/UnrealGold/T3dImporter.cs
@@ -27,7 +27,7 @@ namespace Sabresaurus.SabreCSG.Importers.UnrealGold
 
             // open the file for reading. we use streams for additional performance.
             // it's faster than File.ReadAllLines() as that requires two iterations.
-            using (FileStream stream = new FileStream(path, FileMode.Open))
+            using (FileStream stream = new FileStream(path, FileMode.Open, FileAccess.Read))
             using (StreamReader reader = new StreamReader(stream))
             {
                 // read all the lines from the file.

--- a/Scripts/Importers/ValveMapFormat2006/VmfImporter.cs
+++ b/Scripts/Importers/ValveMapFormat2006/VmfImporter.cs
@@ -25,7 +25,7 @@ namespace Sabresaurus.SabreCSG.Importers.ValveMapFormat2006
 
             // open the file for reading. we use streams for additional performance.
             // it's faster than File.ReadAllLines() as that requires two iterations.
-            using (FileStream stream = new FileStream(path, FileMode.Open))
+            using (FileStream stream = new FileStream(path, FileMode.Open, FileAccess.Read))
             using (StreamReader reader = new StreamReader(stream))
             {
                 // read all the lines from the file.


### PR DESCRIPTION
When I try to import VMF maps, I get an error dialog: "Access to the path .... is denied"

Adding `FileAccess.Read` to the FileStream fixes the issue.