### PR TITLE
Unity 2019.3 fixed vertex, face and paint tool window size.

### DIFF
--- a/Scripts/Tools/PaintEditor.cs
+++ b/Scripts/Tools/PaintEditor.cs
@@ -474,14 +474,22 @@ namespace Sabresaurus.SabreCSG
             switch (drawingMode)
             {
                 case DrawingMode.Color:
+#if UNITY_2019_3_OR_NEWER
+                    toolbarHeight = 230;
+#else
                     toolbarHeight = 217;
+#endif
                     break;
 
                 case DrawingMode.R:
                 case DrawingMode.G:
                 case DrawingMode.B:
                 case DrawingMode.Alpha:
+#if UNITY_2019_3_OR_NEWER
+                    toolbarHeight = 138;
+#else
                     toolbarHeight = 126;
+#endif
                     break;
             }
 

--- a/Scripts/Tools/SurfaceEditor.cs
+++ b/Scripts/Tools/SurfaceEditor.cs
@@ -64,7 +64,11 @@ namespace Sabresaurus.SabreCSG
         private float unroundedDeltaAngle = 0;
 
         // Main UI rectangle for this tool's UI
+#if UNITY_2019_3_OR_NEWER
+        private readonly Rect toolbarRect = new Rect(6, 40, 215, 245);
+#else
         private readonly Rect toolbarRect = new Rect(6, 40, 200, 226);
+#endif
 
         // Used to track what polygons have been previously clicked on, so that the user can cycle click through objects
         // on the same (or similar) ray cast

--- a/Scripts/Tools/VertexEditor.cs
+++ b/Scripts/Tools/VertexEditor.cs
@@ -997,9 +997,13 @@ namespace Sabresaurus.SabreCSG
 				DrawVertices(sceneView, e);
 			}
 
-			// Draw UI specific to this editor
-			Rect rectangle = new Rect(0, 50, 175, 180);
-			GUIStyle toolbar = new GUIStyle(EditorStyles.toolbar);
+            // Draw UI specific to this editor
+#if UNITY_2019_3_OR_NEWER
+            Rect rectangle = new Rect(0, 50, 185, 195);
+#else
+            Rect rectangle = new Rect(0, 50, 175, 180);
+#endif
+            GUIStyle toolbar = new GUIStyle(EditorStyles.toolbar);
 			toolbar.normal.background = SabreCSGResources.ClearTexture;
 			toolbar.fixedHeight = rectangle.height;
 			GUILayout.Window(140002, rectangle, OnToolbarGUI, "", toolbar);


### PR DESCRIPTION
This fixes #242 where the tool windows were too small clipping several buttons and items.