### PR TITLE
Volume brushes are now given nice names in the hierarchy

### DIFF
--- a/Scripts/Brushes/PrimitiveBrush.cs
+++ b/Scripts/Brushes/PrimitiveBrush.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using UnityEngine;
 
 namespace Sabresaurus.SabreCSG
@@ -174,6 +175,12 @@ namespace Sabresaurus.SabreCSG
         {
             get
             {
+                if (volume)
+                {
+                    // give volumes a nice name, where "MyTriggerVolume" becomes "My Trigger Volume"
+                    return Regex.Replace(volume.GetType().Name, "([a-z])([A-Z])", "$1 $2");
+                }
+
                 switch (brushType)
                 {
                     case PrimitiveBrushType.Cube:


### PR DESCRIPTION
This is a lot cleaner than still seeing "Cube Brush", especially when a lot of your game logic relies on them. I used regex to turn "MyTriggerVolume" into "My Trigger Volume".