### PR TITLE
Fixed translation gizmos being unclickable and causing a marquee.

### DIFF
--- a/Scripts/CSGModel.cs
+++ b/Scripts/CSGModel.cs
@@ -1359,8 +1359,10 @@ namespace Sabresaurus.SabreCSG
                 // Then resubscribe and repaint
                 isSubscribedToDuringSceneGui = true;
 #if UNITY_2019_1_OR_NEWER
+                SceneView.duringSceneGui -= OnSceneGUI;
                 SceneView.duringSceneGui += OnSceneGUI;
 #else
+                SceneView.onSceneGUIDelegate -= OnSceneGUI;
                 SceneView.onSceneGUIDelegate += OnSceneGUI;
 #endif
                 SceneView.RepaintAll();


### PR DESCRIPTION
Absolutely ridiculous. It was always like this in the past- but I rewrote how SabreCSG checks whether it was subscribed to the `SceneView.duringSceneGui` because it's a `System.Action` where you can't get an invocation list. Never would I have thought that removing your subscription after a C# reload / Unity Start would be required.

![image](https://user-images.githubusercontent.com/7905726/127780026-ff082abe-96a7-4851-ace8-697571f91780.png)