### PR TITLE
The Vertex Editor failed to weld and corrupted shapes.

### DIFF
--- a/Scripts/Core/CSG/Vertex.cs
+++ b/Scripts/Core/CSG/Vertex.cs
@@ -152,7 +152,7 @@ namespace Sabresaurus.SabreCSG
         {
             return other != null &&
                    EqualityComparer<Vector3>.Default.Equals(Position, other.Position) &&
-                   EqualityComparer<Vector2>.Default.Equals(UV, other.UV) &&
+                   UV.x.Equals(other.UV.x) && UV.y.Equals(other.UV.y) &&
                    EqualityComparer<Vector3>.Default.Equals(Normal, other.Normal) &&
                    EqualityComparer<Color32>.Default.Equals(Color, other.Color);
         }


### PR DESCRIPTION
Unity changed how the .Equals function works in Vector2 (reference source).

**2018:**
```csharp
public bool Equals(Vector2 other)
{
    return x.Equals(other.x) && y.Equals(other.y);
}
```
**2019:**
```csharp
public bool Equals(Vector2 other)
{
    return x == other.x && y == other.y;
}
```

**In Vertex.cs Equals():**

`EqualityComparer<Vector2>.Default.Equals(UV, other.UV)` doesn't work.
`UV.Equals(other.UV)` doesn't work.
`UV == other.UV` doesn't work.
`UV.x == other.UV.x && UV.y == other.UV.y` doesn't work.
`UV.x.Equals(other.UV.x) && UV.y.Equals(other.UV.y)` only this works, or doesn't, which makes the vertex editor work again.

![image](https://user-images.githubusercontent.com/7905726/127830406-b23a93c4-528b-401d-a6cc-2894cad6c67c.png)
![image](https://user-images.githubusercontent.com/7905726/127830741-b7ccd401-8c4f-4b0d-bf0c-244d81a91098.png)

Many thanks to Clor on Discord!