### PR TITLE
Don't show toolbar twice in unity >= 2021_2

### DIFF
--- a/Scripts/UI/Toolbar.cs
+++ b/Scripts/UI/Toolbar.cs
@@ -73,6 +73,7 @@ namespace Sabresaurus.SabreCSG
 				bottomToolbarHeight *= 2;
 			}
 
+#if !UNITY_2021_2_OR_NEWER
             Rect rectangle = new Rect(0, sceneView.position.height - bottomToolbarHeight, sceneView.position.width, bottomToolbarHeight);
 
             GUIStyle style = new GUIStyle(EditorStyles.toolbar);
@@ -104,15 +105,14 @@ namespace Sabresaurus.SabreCSG
 
 				style.fixedHeight = VIEW_MENU_HEIGHT;
 				GUILayout.Window(140012, viewMenuRect, OnViewMenuGUI, "", style);
+
 			}
 
 			style = new GUIStyle(EditorStyles.toolbar);
 
 			style.normal.background = SabreCSGResources.ClearTexture;
 			rectangle = new Rect(0, 20, 320, 50);
-#if !UNITY_2021_2_OR_NEWER  // Displayed in an overlay in unity >= 2021_2
 			GUILayout.Window(140004, rectangle, OnTopToolbarGUI, "", style);
-#endif
 
 			if(!string.IsNullOrEmpty(warningMessage))
 			{				
@@ -120,10 +120,10 @@ namespace Sabresaurus.SabreCSG
 				rectangle = new Rect(0, sceneView.position.height - bottomToolbarHeight - style.fixedHeight, sceneView.position.width, style.fixedHeight);
 				GUILayout.Window(140005, rectangle, OnWarningToolbar, "", style);
 			}
-            
-        }
+#endif
+		}
 
-        public static void OnTopToolbarGUI(int windowID)
+		public static void OnTopToolbarGUI(int windowID)
         {
 			EditorGUILayout.BeginHorizontal();
             MainMode currentMode = CurrentSettings.CurrentMode;

--- a/Scripts/UI/Toolbar.cs
+++ b/Scripts/UI/Toolbar.cs
@@ -110,7 +110,9 @@ namespace Sabresaurus.SabreCSG
 
 			style.normal.background = SabreCSGResources.ClearTexture;
 			rectangle = new Rect(0, 20, 320, 50);
+#if !UNITY_2021_2_OR_NEWER  // Displayed in an overlay in unity >= 2021_2
 			GUILayout.Window(140004, rectangle, OnTopToolbarGUI, "", style);
+#endif
 
 			if(!string.IsNullOrEmpty(warningMessage))
 			{				


### PR DESCRIPTION
First - thanks for your fantastic work!

This is a simple one, the top level toolbar (Resize/Vertex/Face/Clip/Draw) was being drawn once in an overlay and once in the fixed window in unity 2021_2. This removes the latter draw.