### PR TITLE
Ignore 3D textures in materials when in face select mode

### DIFF
--- a/Scripts/Tools/SurfaceEditor.cs
+++ b/Scripts/Tools/SurfaceEditor.cs
@@ -1345,6 +1345,7 @@ namespace Sabresaurus.SabreCSG
                             string assetPath = AssetDatabase.GetAssetPath(newTexture);
                             TextureImporter importer = TextureImporter.GetAtPath(assetPath) as TextureImporter;
 
+                            // The importer may be null on Texture3D.
                             if (importer == null)
                             {
                                 continue;
@@ -1383,7 +1384,10 @@ namespace Sabresaurus.SabreCSG
                 Rect rect = GUILayoutUtility.GetLastRect();
                 rect.position += new Vector2(rect.width, 0);
                 Material drawMaterial = SabreCSGResources.GetPreviewMaterial();
-                drawMaterial.mainTexture = secondaryTexture;
+                if (secondaryTexture != null && secondaryTexture.dimension != UnityEngine.Rendering.TextureDimension.Tex2D)
+                    drawMaterial.mainTexture = null;
+                else
+                    drawMaterial.mainTexture = secondaryTexture;
 
                 if (PlayerSettings.colorSpace == ColorSpace.Linear)
                 {

--- a/Scripts/Tools/SurfaceEditor.cs
+++ b/Scripts/Tools/SurfaceEditor.cs
@@ -1345,6 +1345,11 @@ namespace Sabresaurus.SabreCSG
                             string assetPath = AssetDatabase.GetAssetPath(newTexture);
                             TextureImporter importer = TextureImporter.GetAtPath(assetPath) as TextureImporter;
 
+                            if (importer == null)
+                            {
+                                continue;
+                            }
+
 #if UNITY_5_5_OR_NEWER
                             // Unity 5.5 refactored the TextureImporter, requiring slightly different logic
                             TextureImporterSettings importerSettings = new TextureImporterSettings();


### PR DESCRIPTION
Add dropout if the texture importer doesn't exist for a texture in a material for a selected face in face select mode.
3D textures do not have TextureImporter importers so the cast result is null, which caused endless errors and stopped the UIs from showing anything until this fix was implemented.