### PR TITLE
Fix toolbar in unity builds

### DIFF
--- a/Scripts/UI/SabreToolbarOverlay.cs
+++ b/Scripts/UI/SabreToolbarOverlay.cs
@@ -1,4 +1,4 @@
-﻿#if UNITY_2021_2_OR_NEWER
+﻿#if UNITY_EDITOR && UNITY_2021_2_OR_NEWER
 
 using UnityEditor;
 using UnityEditor.Overlays;

--- a/Scripts/UI/SabreToolsOverlay.cs
+++ b/Scripts/UI/SabreToolsOverlay.cs
@@ -1,4 +1,4 @@
-﻿#if UNITY_2021_2_OR_NEWER
+﻿#if UNITY_EDITOR && UNITY_2021_2_OR_NEWER
 
 using UnityEditor;
 using UnityEditor.Overlays;


### PR DESCRIPTION
I needed these extra pre-processor checks to build the new toolbar.

I'm using asmdef files in my builds too, in case that's making things different for me.